### PR TITLE
Fix DeepSeekClient casing

### DIFF
--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -33,7 +33,7 @@ class SummarizeCommand extends UserCommand
             $raw .= "[{$m['from_user']} @ {$t}] {$m['text']}\n";
         }
 
-        $client = DeepseekClient::build(getenv('DEEPSEEK_API_KEY'));
+        $client = DeepSeekClient::build(getenv('DEEPSEEK_API_KEY'));
         $client->query(
             'Provide a concise summary focusing on tasks, issues, and decisions.',
             'system'

--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -7,11 +7,11 @@ use DeepSeek\DeepSeekClient;
 
 class DeepseekService
 {
-    private DeepseekClient $client;
+    private DeepSeekClient $client;
 
     public function __construct(string $apiKey)
     {
-        $this->client = DeepseekClient::build($apiKey);
+        $this->client = DeepSeekClient::build($apiKey);
     }
 
     public function summarize(string $transcript): string


### PR DESCRIPTION
## Summary
- ensure correct `DeepSeekClient` name in DeepseekService and SummarizeCommand

## Testing
- `composer test` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_688b4f28098883229b20042ed6fa02fc