### PR TITLE
Add monolog-based logging with Telegram alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 .env
 Makefile
+logs/

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "longman/telegram-bot": "^0.83.1",
     "deepseek-php/deepseek-php-client": "^2.0",
     "vlucas/phpdotenv": "^5.0",
-    "ext-pdo": "*"
+    "ext-pdo": "*",
+    "monolog/monolog": "^3.9"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "a2e04c47ea634556a0142c6672709523",
+  "content-hash": "f5c5173cb2fbe3a4e5de5ba2ffc98201",
   "packages": [
     {
       "name": "deepseek-php/deepseek-php-client",
@@ -599,6 +599,109 @@
         }
       ],
       "time": "2024-05-30T21:05:25+00:00"
+    },
+    {
+      "name": "monolog/monolog",
+      "version": "3.9.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/Seldaek/monolog.git",
+        "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+        "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=8.1",
+        "psr/log": "^2.0 || ^3.0"
+      },
+      "provide": {
+        "psr/log-implementation": "3.0.0"
+      },
+      "require-dev": {
+        "aws/aws-sdk-php": "^3.0",
+        "doctrine/couchdb": "~1.0@dev",
+        "elasticsearch/elasticsearch": "^7 || ^8",
+        "ext-json": "*",
+        "graylog2/gelf-php": "^1.4.2 || ^2.0",
+        "guzzlehttp/guzzle": "^7.4.5",
+        "guzzlehttp/psr7": "^2.2",
+        "mongodb/mongodb": "^1.8",
+        "php-amqplib/php-amqplib": "~2.4 || ^3",
+        "php-console/php-console": "^3.1.8",
+        "phpstan/phpstan": "^2",
+        "phpstan/phpstan-deprecation-rules": "^2",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+        "predis/predis": "^1.1 || ^2",
+        "rollbar/rollbar": "^4.0",
+        "ruflin/elastica": "^7 || ^8",
+        "symfony/mailer": "^5.4 || ^6",
+        "symfony/mime": "^5.4 || ^6"
+      },
+      "suggest": {
+        "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+        "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+        "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+        "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+        "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+        "ext-mbstring": "Allow to work properly with unicode symbols",
+        "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+        "ext-openssl": "Required to send log messages using SSL",
+        "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+        "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+        "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+        "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+        "rollbar/rollbar": "Allow sending log messages to Rollbar",
+        "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "3.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Monolog\\": "src/Monolog"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be",
+          "homepage": "https://seld.be"
+        }
+      ],
+      "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+      "homepage": "https://github.com/Seldaek/monolog",
+      "keywords": [
+        "log",
+        "logging",
+        "psr-3"
+      ],
+      "support": {
+        "issues": "https://github.com/Seldaek/monolog/issues",
+        "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/Seldaek",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2025-03-24T10:02:05+00:00"
     },
     {
       "name": "nyholm/psr7",

--- a/public/index.php
+++ b/public/index.php
@@ -5,9 +5,11 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Longman\TelegramBot\Exception\TelegramException;
 use Src\BotHandle;
+use Src\Service\LoggerService;
 
+$logger = LoggerService::getLogger();
 try {
     BotHandle::run();
 } catch (TelegramException $e) {
-    error_log('Index start failed: ' . $e->getMessage());
+    $logger->error('Index start failed: ' . $e->getMessage());
 }

--- a/public/webhook-git.php
+++ b/public/webhook-git.php
@@ -1,8 +1,10 @@
 <?php
 
 use Src\Config\Config;
+use Src\Service\LoggerService;
 
 Config::load(__DIR__ . '/../');
+$logger = LoggerService::getLogger();
 
 
 $secret = Config::get('GIT_SECRET');
@@ -20,7 +22,7 @@ $status = null;
 exec("cd /var/www/bot && git pull origin main && composer install 2>&1", $output, $status);
 
 if ($status !== 0) {
-    error_log("Git pull or composer install failed. Command output: " . implode("\n", $output));
+    $logger->error("Git pull or composer install failed. Command output: " . implode("\n", $output));
     http_response_code(500);
     exit("Git pull or composer install failed");
 }

--- a/scripts/daily_report.php
+++ b/scripts/daily_report.php
@@ -8,13 +8,16 @@ use Src\Repository\MySQLMessageRepository;
 use Src\Service\DeepseekService;
 use Src\Service\ReportService;
 use Src\Service\TelegramService;
+use Src\Service\LoggerService;
 
 Config::load(__DIR__ . '/..');
+$logger = LoggerService::getLogger();
 date_default_timezone_set('Europe/Moscow');
 
 $repo = new MySQLMessageRepository();
 $deepseek = new DeepseekService(Config::get('DEEPSEEK_API_KEY'));
 $telegram = new TelegramService();
+$logger->info('Daily report script started');
 $report = new ReportService(
     $repo,
     $deepseek,
@@ -23,3 +26,4 @@ $report = new ReportService(
 );
 
 $report->runDailyReports(time());
+$logger->info('Daily report script finished');

--- a/src/BotHandle.php
+++ b/src/BotHandle.php
@@ -6,6 +6,7 @@ namespace Src;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Telegram;
 use Src\Config\Config;
+use Src\Service\LoggerService;
 
 class BotHandle
 {
@@ -15,6 +16,8 @@ class BotHandle
     public static function run(): void
     {
         Config::load(__DIR__ . '/../');
+        $logger = LoggerService::getLogger();
+        $logger->info('Bot starting');
 
         $telegram = new Telegram(
             Config::get('TELEGRAM_BOT_TOKEN'),
@@ -25,5 +28,6 @@ class BotHandle
         $telegram->addCommandsPath(__DIR__ . '/Commands/UserCommands');
 
         $telegram->handle();
+        $logger->info('Bot handled request');
     }
 }

--- a/src/Commands/SystemCommands/GenericmessageCommand.php
+++ b/src/Commands/SystemCommands/GenericmessageCommand.php
@@ -7,12 +7,20 @@ use Longman\TelegramBot\Commands\SystemCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Request;
 use Src\Repository\MySQLMessageRepository;
+use Src\Service\LoggerService;
 
 class GenericmessageCommand extends SystemCommand
 {
     protected $name = 'genericmessage';
     protected $description = 'Handles every incoming message';
     protected $version = '1.0.0';
+    private $logger;
+
+    public function __construct(...$args)
+    {
+        parent::__construct(...$args);
+        $this->logger = LoggerService::getLogger();
+    }
 
     public function execute(): ServerResponse
     {
@@ -22,6 +30,7 @@ class GenericmessageCommand extends SystemCommand
             return Request::emptyResponse();
         }
 
+        $this->logger->info('Incoming message', ['chat_id' => $message->getChat()->getId()]);
         (new MySQLMessageRepository())->add(
             $message->getChat()->getId(),
             [

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -8,6 +8,7 @@ use Longman\TelegramBot\Commands\UserCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Request;
 use Src\Repository\MySQLMessageRepository;
+use Src\Service\LoggerService;
 
 class SummarizeCommand extends UserCommand
 {
@@ -15,10 +16,18 @@ class SummarizeCommand extends UserCommand
     protected $description = 'On‑demand summary of today’s chat';
     protected $usage = '/summarize';
     protected $version = '1.0.0';
+    private $logger;
+
+    public function __construct(...$args)
+    {
+        parent::__construct(...$args);
+        $this->logger = LoggerService::getLogger();
+    }
 
     public function execute(): ServerResponse
     {
         $chatId = $this->getMessage()->getChat()->getId();
+        $this->logger->info('Summarize command triggered', ['chat_id' => $chatId]);
         $repo = new MySQLMessageRepository();
         $todayTs = time();
 
@@ -40,13 +49,16 @@ class SummarizeCommand extends UserCommand
         );
         $client->query($raw, 'user');
         $summary = $client->run();
+        $this->logger->info('Summary generated', ['chat_id' => $chatId]);
 
         $repo->markProcessed($chatId, $todayTs);
-
-        return Request::sendMessage([
+        $this->logger->info('Messages marked processed after summarize', ['chat_id' => $chatId]);
+        $response = Request::sendMessage([
             'chat_id' => $chatId,
             'text' => "*Chat Summary:*\n{$summary}",
             'parse_mode' => 'Markdown',
         ]);
+        $this->logger->info('Summary sent to chat', ['chat_id' => $chatId]);
+        return $response;
     }
 }

--- a/src/Service/LoggerService.php
+++ b/src/Service/LoggerService.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Service;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+class LoggerService
+{
+    private static ?LoggerInterface $logger = null;
+
+    public static function getLogger(): LoggerInterface
+    {
+        if (self::$logger === null) {
+            $logger = new Logger('bot');
+            $logFile = __DIR__ . '/../../logs/app.log';
+            $logger->pushHandler(new StreamHandler($logFile, Logger::DEBUG));
+            $logger->pushHandler(new TelegramLogHandler(Logger::ERROR));
+            self::$logger = $logger;
+        }
+        return self::$logger;
+    }
+}

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -4,20 +4,24 @@ declare(strict_types=1);
 namespace Src\Service;
 
 use Src\Repository\MessageRepositoryInterface;
+use Src\Service\LoggerService;
 
 class ReportService
 {
+    private LoggerService $logger;
+
     public function __construct(
         private MessageRepositoryInterface $repo,
         private DeepseekService            $deepseek,
         private TelegramService            $telegram,
         private int                        $summaryChatId
-    )
-    {
+    ) {
+        $this->logger = LoggerService::getLogger();
     }
 
     public function runDailyReports(int $dayTs): void
     {
+        $this->logger->info('Running daily reports', ['day' => date('Y-m-d', $dayTs)]);
         foreach ($this->repo->listActiveChats($dayTs) as $chatId) {
             $msgs = $this->repo->getMessagesForChat($chatId, $dayTs);
             if (empty($msgs)) {
@@ -33,6 +37,7 @@ class ReportService
             $summary = $this->deepseek->summarize($transcript);
             $header = "*Report for chat* `{$chatId}`\n_" . date('Y-m-d', $dayTs) . "_\n\n";
             $this->telegram->sendMessage($this->summaryChatId, $header . $summary);
+            $this->logger->info('Daily report sent', ['chat_id' => $chatId]);
             $this->repo->markProcessed($chatId, $dayTs);
         }
     }

--- a/src/Service/TelegramLogHandler.php
+++ b/src/Service/TelegramLogHandler.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Service;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+class TelegramLogHandler extends AbstractProcessingHandler
+{
+    private TelegramService $telegram;
+    private int $chatId = -1002671594630;
+
+    public function __construct(int $level = Logger::ERROR, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+        $this->telegram = new TelegramService();
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        $message = sprintf("%s: %s", $record->level->getName(), (string) $record->message);
+        $this->telegram->sendMessage($this->chatId, $message);
+    }
+}

--- a/src/Service/TelegramService.php
+++ b/src/Service/TelegramService.php
@@ -5,11 +5,16 @@ namespace Src\Service;
 
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
+use Psr\Log\LoggerInterface;
+use Src\Service\LoggerService;
 
 class TelegramService
 {
+    private LoggerInterface $logger;
+
     public function __construct()
-    { /* nothing */
+    {
+        $this->logger = LoggerService::getLogger();
     }
 
     public function sendMessage(int $chatId, string $text): void
@@ -20,8 +25,9 @@ class TelegramService
                 'text' => $text,
                 'parse_mode' => 'Markdown',
             ]);
+            $this->logger->info('Sent message to Telegram', ['chat_id' => $chatId]);
         } catch (TelegramException $e) {
-            error_log('Telegram sendMessage failed: ' . $e->getMessage());
+            $this->logger->error('Telegram sendMessage failed: ' . $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Monolog dependency
- log messages across services and commands
- send Telegram notifications on errors using TelegramLogHandler
- ignore logs directory

## Testing
- `composer install`
- `composer test` *(fails: shows PHPUnit usage)*
- `./vendor/bin/phpunit` *(shows usage since no tests)*
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_688b507a23c883228c8b6fc47a6cc9e0