### PR TITLE
Increase PHP memory limit for bot operations

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+// Increase memory limit to avoid Monolog exhausting default 128M
+ini_set('memory_limit', '256M');
+
 use Longman\TelegramBot\Exception\TelegramException;
 use Src\BotHandle;
 use Src\Service\LoggerService;

--- a/scripts/daily_report.php
+++ b/scripts/daily_report.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+// Increase memory limit for daily summarization process
+ini_set('memory_limit', '256M');
+
 use Src\Config\Config;
 use Src\Repository\MySQLMessageRepository;
 use Src\Service\DeepseekService;


### PR DESCRIPTION
## Summary
- bump PHP memory limit to 256M for web entry and daily reports

## Testing
- `composer install`
- `composer test` *(fails: shows PHPUnit usage because no tests are present)*

------
https://chatgpt.com/codex/tasks/task_e_688b56e4bb088322a1dcc1de2e585008