### PR TITLE
Fix logger recursion

### DIFF
--- a/src/Service/LoggerService.php
+++ b/src/Service/LoggerService.php
@@ -15,10 +15,13 @@ class LoggerService
     {
         if (self::$logger === null) {
             $logger = new Logger('bot');
+            // Set the static instance before adding handlers to avoid
+            // recursive calls when handlers depend on the logger.
+            self::$logger = $logger;
+
             $logFile = __DIR__ . '/../../logs/app.log';
             $logger->pushHandler(new StreamHandler($logFile, Logger::DEBUG));
             $logger->pushHandler(new TelegramLogHandler(Logger::ERROR));
-            self::$logger = $logger;
         }
         return self::$logger;
     }


### PR DESCRIPTION
## Summary
- ensure logger is stored before pushing handlers

## Testing
- `composer test` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_688b58f4408c8322b8fbf9d995ad21e5