### PR TITLE
Fix .env path for DB repository

### DIFF
--- a/src/Repository/MySQLMessageRepository.php
+++ b/src/Repository/MySQLMessageRepository.php
@@ -15,7 +15,8 @@ class MySQLMessageRepository implements MessageRepositoryInterface
 
     public function __construct()
     {
-        Config::load(__DIR__ . '/..');
+        // Load configuration from the project root rather than src/Repository
+        Config::load(dirname(__DIR__, 2));
 
         $dsn = sprintf(
             'mysql:host=%s;dbname=%s;charset=utf8mb4',


### PR DESCRIPTION
## Summary
- fix Config::load path in MySQLMessageRepository

## Testing
- `composer install`
- `composer test` *(fails: PHPUnit missing configuration)*


------
https://chatgpt.com/codex/tasks/task_e_688b5fc1ea3c8322a5ff3ff923f15d46