### PR TITLE
Implement QA recommendations

### DIFF
--- a/public/webhook-git.php
+++ b/public/webhook-git.php
@@ -1,10 +1,16 @@
 <?php
+require __DIR__ . '/../vendor/autoload.php';
 
 use Src\Config\Config;
 use Src\Service\LoggerService;
 
 Config::load(__DIR__ . '/../');
 $logger = LoggerService::getLogger();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Method Not Allowed');
+}
 
 
 $secret = Config::get('GIT_SECRET');

--- a/scripts/daily_report.php
+++ b/scripts/daily_report.php
@@ -12,12 +12,13 @@ use Src\Service\DeepseekService;
 use Src\Service\ReportService;
 use Src\Service\TelegramService;
 use Src\Service\LoggerService;
+use Src\Util\DbConnection;
 
 Config::load(__DIR__ . '/..');
 $logger = LoggerService::getLogger();
 date_default_timezone_set('Europe/Moscow');
 
-$repo = new MySQLMessageRepository();
+$repo = new MySQLMessageRepository(DbConnection::get(), $logger);
 $deepseek = new DeepseekService(Config::get('DEEPSEEK_API_KEY'));
 $telegram = new TelegramService();
 $logger->info('Daily report script started');

--- a/src/Commands/SystemCommands/GenericmessageCommand.php
+++ b/src/Commands/SystemCommands/GenericmessageCommand.php
@@ -8,6 +8,7 @@ use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Request;
 use Src\Repository\MySQLMessageRepository;
 use Src\Service\LoggerService;
+use Src\Util\DbConnection;
 
 class GenericmessageCommand extends SystemCommand
 {
@@ -37,7 +38,8 @@ class GenericmessageCommand extends SystemCommand
             'text' => $text,
         ]);
 
-        (new MySQLMessageRepository())->add(
+        $repo = new MySQLMessageRepository(DbConnection::get(), $this->logger);
+        $repo->add(
             $message->getChat()->getId(),
             [
                 'message_id' => $message->getMessageId(),

--- a/src/Commands/UserCommands/StartCommand.php
+++ b/src/Commands/UserCommands/StartCommand.php
@@ -7,6 +7,7 @@ use Longman\TelegramBot\Commands\UserCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
+use Src\Service\LoggerService;
 
 /**
  * Class StartCommand
@@ -19,6 +20,13 @@ class StartCommand extends UserCommand
     protected $description = 'Start command';
     protected $usage = '/start';
     protected $version = '1.0.0';
+    private $logger;
+
+    public function __construct(...$args)
+    {
+        parent::__construct(...$args);
+        $this->logger = \Src\Service\LoggerService::getLogger();
+    }
 
     /**
      * Execute the command.
@@ -28,12 +36,8 @@ class StartCommand extends UserCommand
      */
     public function execute(): ServerResponse
     {
-        $message = $this->getMessage();
-        $chat = $message->getChat();
-        $chatId = $message->getChat()->getId();
-        $user = $message->getFrom();
-
-        $text = 'Hey';
+        $chatId = $this->getMessage()->getChat()->getId();
+        $text   = 'Hey';
 
         try {
             return Request::sendMessage([
@@ -42,11 +46,8 @@ class StartCommand extends UserCommand
                 'parse_mode' => 'Markdown',
             ]);
         } catch (Exception $e) {
-            return Request::sendMessage([
-                'chat_id' => $chatId,
-                'text' => $text,
-                'parse_mode' => 'Markdown',
-            ]);
+            $this->logger->error('Start command failed: ' . $e->getMessage());
+            return Request::emptyResponse();
         }
     }
 }

--- a/src/Repository/MySQLMessageRepository.php
+++ b/src/Repository/MySQLMessageRepository.php
@@ -5,30 +5,16 @@ namespace Src\Repository;
 
 use PDO;
 use Psr\Log\LoggerInterface;
-use Src\Config\Config;
-use Src\Service\LoggerService;
 
 class MySQLMessageRepository implements MessageRepositoryInterface
 {
     private PDO $pdo;
     private LoggerInterface $logger;
 
-    public function __construct()
+    public function __construct(PDO $pdo, LoggerInterface $logger)
     {
-        Config::load(dirname(__DIR__, 2));
-
-        $dsn = sprintf(
-            'mysql:host=%s;dbname=%s;charset=utf8mb4',
-            config::get('DB_HOST'),
-            config::get('DB_NAME')
-        );
-        $this->pdo = new PDO(
-            $dsn,
-            config::get('DB_USER'),
-            config::get('DB_PASS'),
-            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
-        );
-        $this->logger = LoggerService::getLogger();
+        $this->pdo = $pdo;
+        $this->logger = $logger;
     }
 
     public function add(int $chatId, array $message): void

--- a/src/Service/LoggerService.php
+++ b/src/Service/LoggerService.php
@@ -6,6 +6,7 @@ namespace Src\Service;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use Src\Config\Config;
 
 class LoggerService
 {
@@ -20,8 +21,15 @@ class LoggerService
             self::$logger = $logger;
 
             $logFile = __DIR__ . '/../../logs/app.log';
+            $logDir  = dirname($logFile);
+            if (!is_dir($logDir)) {
+                mkdir($logDir, 0777, true);
+            }
+
             $logger->pushHandler(new StreamHandler($logFile, Logger::DEBUG));
-            $logger->pushHandler(new TelegramLogHandler(Logger::ERROR));
+            $chatIdEnv = Config::get('LOG_CHAT_ID');
+            $chatId = $chatIdEnv !== '' ? (int)$chatIdEnv : -1002671594630;
+            $logger->pushHandler(new TelegramLogHandler($chatId, Logger::ERROR));
         }
         return self::$logger;
     }

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -5,10 +5,12 @@ namespace Src\Service;
 
 use Src\Repository\MessageRepositoryInterface;
 use Src\Service\LoggerService;
+use Psr\Log\LoggerInterface;
+use Src\Util\TextUtils;
 
 class ReportService
 {
-    private LoggerService $logger;
+    private LoggerInterface $logger;
 
     public function __construct(
         private MessageRepositoryInterface $repo,
@@ -28,11 +30,7 @@ class ReportService
                 continue;
             }
 
-            $transcript = '';
-            foreach ($msgs as $m) {
-                $t = date('H:i', $m['message_date']);
-                $transcript .= "[{$m['from_user']} @ {$t}] {$m['text']}\n";
-            }
+            $transcript = \Src\Util\TextUtils::buildTranscript($msgs);
 
             $summary = $this->deepseek->summarize($transcript);
             $header = "*Report for chat* `{$chatId}`\n_" . date('Y-m-d', $dayTs) . "_\n\n";

--- a/src/Service/TelegramLogHandler.php
+++ b/src/Service/TelegramLogHandler.php
@@ -10,12 +10,13 @@ use Monolog\LogRecord;
 class TelegramLogHandler extends AbstractProcessingHandler
 {
     private TelegramService $telegram;
-    private int $chatId = -1002671594630;
+    private int $chatId;
 
-    public function __construct(int $level = Logger::INFO, bool $bubble = true)
+    public function __construct(int $chatId, int $level = Logger::INFO, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
         $this->telegram = new TelegramService();
+        $this->chatId = $chatId;
     }
 
     protected function write(LogRecord $record): void

--- a/src/Util/DbConnection.php
+++ b/src/Util/DbConnection.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Util;
+
+use PDO;
+use Src\Config\Config;
+
+class DbConnection
+{
+    private static ?PDO $pdo = null;
+
+    public static function get(): PDO
+    {
+        if (self::$pdo === null) {
+            $dsn = sprintf(
+                'mysql:host=%s;dbname=%s;charset=utf8mb4',
+                Config::get('DB_HOST'),
+                Config::get('DB_NAME')
+            );
+            self::$pdo = new PDO(
+                $dsn,
+                Config::get('DB_USER'),
+                Config::get('DB_PASS'),
+                [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+            );
+        }
+        return self::$pdo;
+    }
+}

--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Util;
+
+class TextUtils
+{
+    public static function buildTranscript(array $messages): string
+    {
+        $transcript = '';
+        foreach ($messages as $m) {
+            $t = date('H:i', $m['message_date']);
+            $transcript .= "[{$m['from_user']} @ {$t}] {$m['text']}\n";
+        }
+        return $transcript;
+    }
+
+    public static function escapeMarkdown(string $text): string
+    {
+        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'];
+        foreach ($special as $char) {
+            $text = str_replace($char, '\\' . $char, $text);
+        }
+        return $text;
+    }
+}


### PR DESCRIPTION
## Summary
- improve LoggerService to create log dir and configurable log chat
- allow TelegramLogHandler chat ID injection
- use single PDO connection and refactor repository constructors
- extract transcript and markdown helpers
- clean up commands and secure webhook handler

## Testing
- `composer install`
- `composer test` *(fails: PHPUnit usage message)*

------
https://chatgpt.com/codex/tasks/task_e_688b66cb80b883229dd016d3977038be