### PR TITLE
Refactor DB layer and logger

### DIFF
--- a/src/Commands/SystemCommands/GenericmessageCommand.php
+++ b/src/Commands/SystemCommands/GenericmessageCommand.php
@@ -30,7 +30,7 @@ class GenericmessageCommand extends SystemCommand
 
         $conn = Database::getConnection($this->logger);
         $repo   = new DbalMessageRepository($conn, $this->logger);
-        $logger = new MessageLogger($repo);
+        $logger = new MessageLogger($repo, $this->logger);
         $logger->handleUpdate($update);
 
         return Request::emptyResponse();

--- a/src/Logger/MessageLogger.php
+++ b/src/Logger/MessageLogger.php
@@ -5,22 +5,22 @@ namespace Src\Logger;
 
 use Longman\TelegramBot\Entities\Update;
 use Psr\Log\LoggerInterface;
-use Src\Config\Config;
 use Src\Entity\Message;
 use Src\Repository\MessageRepositoryInterface;
-use Src\Service\LoggerService;
 
 /**
  * Handles incoming Telegram updates and persists relevant messages.
  */
 class MessageLogger
 {
-    private LoggerInterface $logger;
+    private string $chatPattern;
 
     public function __construct(
-        private MessageRepositoryInterface $repository
+        private MessageRepositoryInterface $repository,
+        private LoggerInterface $logger,
+        string $chatPattern = '/AIO/i'
     ) {
-        $this->logger = LoggerService::getLogger();
+        $this->chatPattern = $chatPattern;
     }
 
     /**
@@ -33,10 +33,10 @@ class MessageLogger
             return; // ignore non-message updates
         }
 
-        $chat = $message->getChat();
+        $chat  = $message->getChat();
         $title = $chat->getTitle();
-        if ($title === null || stripos($title, 'AIO') === false) {
-            // Only process chats containing "AIO" in the title
+        if ($title === null || !preg_match($this->chatPattern, $title)) {
+            // Only process chats matching the allowed pattern
             return;
         }
 

--- a/src/Service/Database.php
+++ b/src/Service/Database.php
@@ -22,14 +22,19 @@ class Database
     public static function getConnection(LoggerInterface $logger): Connection
     {
         if (self::$connection === null) {
-            $params = [
-                'dbname'   => Config::get('DB_NAME'),
-                'user'     => Config::get('DB_USER'),
-                'password' => Config::get('DB_PASS'),
-                'host'     => Config::get('DB_HOST'),
-                'driver'   => 'pdo_mysql',
-                'charset'  => 'utf8mb4',
-            ];
+            $url = Config::get('DATABASE_URL');
+            if ($url !== '') {
+                $params = ['url' => $url];
+            } else {
+                $params = [
+                    'dbname'   => Config::get('DB_NAME'),
+                    'user'     => Config::get('DB_USER'),
+                    'password' => Config::get('DB_PASS'),
+                    'host'     => Config::get('DB_HOST'),
+                    'driver'   => 'pdo_mysql',
+                    'charset'  => 'utf8mb4',
+                ];
+            }
             $config = new Configuration();
             $config->setSQLLogger(new class($logger) implements SQLLogger {
                 public function __construct(private LoggerInterface $logger) {}

--- a/tests/MessageLoggerTest.php
+++ b/tests/MessageLoggerTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+use Longman\TelegramBot\Entities\Update;
+use PHPUnit\Framework\TestCase;
+use Src\Logger\MessageLogger;
+use Src\Repository\DbalMessageRepository;
+use Src\Service\Database;
+use Psr\Log\NullLogger;
+use Doctrine\DBAL\DriverManager;
+
+class MessageLoggerTest extends TestCase
+{
+    private \Doctrine\DBAL\Connection $conn;
+
+    protected function setUp(): void
+    {
+        $this->conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        Database::setConnection($this->conn);
+        $this->conn->executeStatement('CREATE TABLE chats (id INTEGER PRIMARY KEY, title VARCHAR(255))');
+        $this->conn->executeStatement('CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, message_id INTEGER NOT NULL, from_user VARCHAR(255) NOT NULL, message_date INT NOT NULL, text LONGTEXT NOT NULL, attachments LONGTEXT DEFAULT NULL, processed TINYINT NOT NULL DEFAULT 0)');
+        $this->conn->executeStatement('CREATE UNIQUE INDEX uq_chat_message ON messages (chat_id, message_id)');
+    }
+
+    public function testStoresMessageForAioChat(): void
+    {
+        $data = [
+            'update_id' => 1,
+            'message' => [
+                'message_id' => 10,
+                'date' => 1,
+                'chat' => ['id' => 1, 'title' => 'My AIO Group', 'type' => 'group'],
+                'from' => ['id' => 2, 'username' => 'u'],
+                'text' => 'hi',
+            ],
+        ];
+        $update = new Update($data);
+        $repo = new DbalMessageRepository($this->conn, new NullLogger());
+        $logger = new MessageLogger($repo, new NullLogger());
+        $logger->handleUpdate($update);
+
+        $count = (int) $this->conn->fetchOne('SELECT COUNT(*) FROM messages');
+        $this->assertSame(1, $count);
+    }
+
+    public function testIgnoresOtherChats(): void
+    {
+        $data = [
+            'update_id' => 2,
+            'message' => [
+                'message_id' => 11,
+                'date' => 1,
+                'chat' => ['id' => 2, 'title' => 'Random Group', 'type' => 'group'],
+                'from' => ['id' => 3, 'username' => 'v'],
+                'text' => 'hello',
+            ],
+        ];
+        $update = new Update($data);
+        $repo = new DbalMessageRepository($this->conn, new NullLogger());
+        $logger = new MessageLogger($repo, new NullLogger());
+        $logger->handleUpdate($update);
+
+        $count = (int) $this->conn->fetchOne('SELECT COUNT(*) FROM messages');
+        $this->assertSame(0, $count);
+    }
+}


### PR DESCRIPTION
## Summary
- unify DB connection handling via `DATABASE_URL`
- make MessageLogger pattern configurable and inject logger
- make GenericmessageCommand use new MessageLogger constructor
- remove DB-specific UPSERT and rely on insert/update for chats
- add MessageLogger tests

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688b75bf9c848322b800657427b7c7e3