### PR TITLE
Ensure config loaded and add test

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,8 +3,12 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use Src\Config\Config;
+
 // Increase memory limit to avoid Monolog exhausting default 128M
 ini_set('memory_limit', '256M');
+
+Config::load(__DIR__ . '/..');
 
 use Longman\TelegramBot\Exception\TelegramException;
 use Src\BotHandle;

--- a/scripts/migrate.php
+++ b/scripts/migrate.php
@@ -1,0 +1,11 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Src\Config\Config;
+
+Config::load(__DIR__ . '/..');
+
+require __DIR__ . '/../vendor/doctrine/migrations/bin/doctrine-migrations.php';

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Src\Config\Config;
+
+class ConfigTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/configtest_' . uniqid();
+        mkdir($this->dir);
+        file_put_contents($this->dir . '/.env', "SOME_VAR=test_value\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $envFile = $this->dir . '/.env';
+        if (file_exists($envFile)) {
+            unlink($envFile);
+        }
+        rmdir($this->dir);
+    }
+
+    public function testLoadEnv(): void
+    {
+        Config::load($this->dir);
+        $this->assertSame('test_value', Config::get('SOME_VAR'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- load environment with `Config::load()` in web index
- add migration wrapper that sets up environment
- cover config loading with a new PHPUnit test

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688b82cd84208322bafd06f721784e2b