### PR TITLE
Add unit tests for reports and config

### DIFF
--- a/src/Command/DailyReportCommand.php
+++ b/src/Command/DailyReportCommand.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Command;
+
+use Src\Service\ReportService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DailyReportCommand extends Command
+{
+    protected static $defaultName = 'app:daily-report';
+
+    public function __construct(private ReportService $service)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Generate daily reports for chats');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->service->runDailyReports(time());
+        return Command::SUCCESS;
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Src\Config\Config;
+use Src\Service\Database;
+use Psr\Log\NullLogger;
+
+class ConfigTest extends TestCase
+{
+    public function testLoadsEnvFile(): void
+    {
+        $dir = sys_get_temp_dir() . '/cfg' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/.env', "FOO=bar\nDATABASE_URL=sqlite:///:memory:\n");
+
+        Config::load($dir);
+        $this->assertSame('bar', Config::get('FOO'));
+    }
+
+    public function testDatabaseConnectionFromEnv(): void
+    {
+        $dir = sys_get_temp_dir() . '/db' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/.env', "DATABASE_URL=sqlite:///:memory:\n");
+        Config::load($dir);
+
+        $ref = new ReflectionClass(Database::class);
+        $prop = $ref->getProperty('connection');
+        $prop->setAccessible(true);
+        $prop->setValue(null);
+
+        $conn = Database::getConnection(new NullLogger());
+        $conn->executeStatement('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)');
+        $conn->insert('t', ['name' => 'foo']);
+        $this->assertSame('foo', $conn->fetchOne('SELECT name FROM t WHERE id = 1'));
+    }
+}

--- a/tests/DailyReportCommandTest.php
+++ b/tests/DailyReportCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Src\Command\DailyReportCommand;
+use Src\Service\ReportService;
+
+class DailyReportCommandTest extends TestCase
+{
+    public function testCommandRunsReportService(): void
+    {
+        $service = $this->createMock(ReportService::class);
+        $service->expects($this->once())
+            ->method('runDailyReports');
+
+        $command = new DailyReportCommand($service);
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        $this->assertSame(0, $status);
+    }
+}

--- a/tests/ReportServiceTest.php
+++ b/tests/ReportServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Src\Service\ReportService;
+use Src\Repository\MessageRepositoryInterface;
+use Src\Service\DeepseekService;
+use Src\Service\TelegramService;
+
+class ReportServiceTest extends TestCase
+{
+    public function testGeneratesAndSendsReports(): void
+    {
+        $repo = $this->createMock(MessageRepositoryInterface::class);
+        $deepseek = $this->createMock(DeepseekService::class);
+        $telegram = $this->createMock(TelegramService::class);
+
+        $day = strtotime('2025-07-31');
+
+        $repo->expects($this->once())
+            ->method('listActiveChats')
+            ->with($day)
+            ->willReturn([1]);
+
+        $messages = [
+            ['from_user' => 'u', 'message_date' => $day + 3600, 'text' => 'hi'],
+            ['from_user' => 'v', 'message_date' => $day + 7200, 'text' => 'there'],
+        ];
+
+        $repo->expects($this->once())
+            ->method('getMessagesForChat')
+            ->with(1, $day)
+            ->willReturn($messages);
+
+        $transcript = "[u @ 01:00] hi\n[v @ 02:00] there\n";
+        $deepseek->expects($this->once())
+            ->method('summarize')
+            ->with($transcript)
+            ->willReturn('summary');
+
+        $telegram->expects($this->once())
+            ->method('sendMessage')
+            ->with(99, "*Report for chat* `1`\n_" . date('Y-m-d', $day) . "_\n\nsummary");
+
+        $repo->expects($this->once())
+            ->method('markProcessed')
+            ->with(1, $day);
+
+        $service = new ReportService($repo, $deepseek, $telegram, 99);
+        $service->runDailyReports($day);
+    }
+
+    public function testSkipsChatsWithNoMessages(): void
+    {
+        $repo = $this->createMock(MessageRepositoryInterface::class);
+        $deepseek = $this->createMock(DeepseekService::class);
+        $telegram = $this->createMock(TelegramService::class);
+
+        $day = strtotime('2025-07-31');
+
+        $repo->expects($this->once())
+            ->method('listActiveChats')
+            ->with($day)
+            ->willReturn([2]);
+
+        $repo->expects($this->once())
+            ->method('getMessagesForChat')
+            ->with(2, $day)
+            ->willReturn([]);
+
+        $deepseek->expects($this->never())->method('summarize');
+        $telegram->expects($this->never())->method('sendMessage');
+        $repo->expects($this->never())->method('markProcessed');
+
+        $service = new ReportService($repo, $deepseek, $telegram, 99);
+        $service->runDailyReports($day);
+    }
+}


### PR DESCRIPTION
## Summary
- cover ReportService interactions
- add DailyReportCommand and test via CommandTester
- extend config/database tests with temp environment
- ensure Doctrine connection works with sqlite URLs

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_688b82d338708322b8897b85515b49f0