### PR TITLE
Add force summary command and improve output parsing

### DIFF
--- a/src/Commands/UserCommands/ForceSummarizeCommand.php
+++ b/src/Commands/UserCommands/ForceSummarizeCommand.php
@@ -3,22 +3,22 @@ declare(strict_types=1);
 
 namespace Src\Commands\UserCommands;
 
-use Src\Service\DeepseekService;
 use Longman\TelegramBot\Commands\UserCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
-use Longman\TelegramBot\Request;
 use Longman\TelegramBot\Entities\Keyboard;
+use Longman\TelegramBot\Request;
 use Src\Config\Config;
 use Src\Repository\DbalMessageRepository;
-use Src\Service\LoggerService;
 use Src\Service\Database;
+use Src\Service\LoggerService;
+use Src\Service\DeepseekService;
 use Src\Util\TextUtils;
 
-class SummarizeCommand extends UserCommand
+class ForceSummarizeCommand extends UserCommand
 {
-    protected $name = 'summarize';
-    protected $description = 'On‑demand summary of today’s chat';
-    protected $usage = '/summarize';
+    protected $name = 'forcesummarize';
+    protected $description = 'Summarize chat ignoring processed flag';
+    protected $usage = '/forcesummarize';
     protected $version = '1.0.0';
     private $logger;
 
@@ -31,7 +31,7 @@ class SummarizeCommand extends UserCommand
     public function execute(): ServerResponse
     {
         $chatId = $this->getMessage()->getChat()->getId();
-        $this->logger->info('Summarize command triggered', ['chat_id' => $chatId]);
+        $this->logger->info('Force summarize command triggered', ['chat_id' => $chatId]);
         $conn = Database::getConnection($this->logger);
         $repo = new DbalMessageRepository($conn, $this->logger);
 
@@ -47,7 +47,7 @@ class SummarizeCommand extends UserCommand
                 'resize_keyboard' => true,
                 'one_time_keyboard' => true,
             ]);
-            return $this->replyToChat('Send /summarize <chat_id> [YYYY-MM-DD]', [
+            return $this->replyToChat('Send /forcesummarize <chat_id> [YYYY-MM-DD]', [
                 'reply_markup' => $keyboard,
             ]);
         }
@@ -59,7 +59,7 @@ class SummarizeCommand extends UserCommand
             return $this->replyToChat('Invalid date format, use YYYY-MM-DD');
         }
 
-        $msgs = $repo->getMessagesForChat($targetId, $dayTs);
+        $msgs = $repo->getAllMessagesForChat($targetId, $dayTs);
         if (empty($msgs)) {
             return $this->replyToChat('No messages to summarize yet.');
         }
@@ -67,17 +67,14 @@ class SummarizeCommand extends UserCommand
         $raw = TextUtils::buildTranscript($msgs);
         $deepseek = new DeepseekService(Config::get('DEEPSEEK_API_KEY'));
         $summary = $deepseek->summarize($raw);
-        $this->logger->info('Summary generated', ['chat_id' => $targetId]);
-
-        $repo->markProcessed($targetId, $dayTs);
-        $this->logger->info('Messages marked processed after summarize', ['chat_id' => $targetId]);
+        $this->logger->info('Force summary generated', ['chat_id' => $targetId]);
 
         $response = Request::sendMessage([
             'chat_id' => $chatId,
             'text' => "*Chat Summary:*\n" . TextUtils::escapeMarkdown($summary),
             'parse_mode' => 'MarkdownV2',
         ]);
-        $this->logger->info('Summary sent to chat', ['chat_id' => $chatId]);
+        $this->logger->info('Force summary sent to chat', ['chat_id' => $chatId]);
         return $response;
     }
 }

--- a/src/Repository/DbalMessageRepository.php
+++ b/src/Repository/DbalMessageRepository.php
@@ -68,6 +68,16 @@ class DbalMessageRepository implements MessageRepositoryInterface
         return $rows;
     }
 
+    public function getAllMessagesForChat(int $chatId, int $dayTs): array
+    {
+        $start = strtotime('midnight', $dayTs);
+        $end = $start + 86400 - 1;
+        $sql = 'SELECT from_user, message_date, text FROM messages WHERE chat_id = :chat AND message_date BETWEEN :start AND :end ORDER BY message_date';
+        $rows = $this->conn->fetchAllAssociative($sql, ['chat' => $chatId, 'start' => $start, 'end' => $end]);
+        $this->logger->info('All messages fetched', ['chat_id' => $chatId, 'count' => count($rows)]);
+        return $rows;
+    }
+
     public function markProcessed(int $chatId, int $dayTs): void
     {
         $start = strtotime('midnight', $dayTs);

--- a/src/Repository/MessageRepositoryInterface.php
+++ b/src/Repository/MessageRepositoryInterface.php
@@ -11,6 +11,11 @@ interface MessageRepositoryInterface
 
     public function getMessagesForChat(int $chatId, int $dayTs): array;
 
+    /**
+     * Fetch all messages for a chat ignoring processed flag.
+     */
+    public function getAllMessagesForChat(int $chatId, int $dayTs): array;
+
     public function markProcessed(int $chatId, int $dayTs): void;
 
     public function listChats(): array;

--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -21,6 +21,11 @@ class DeepseekService
             'system'
         );
         $this->client->query($transcript, 'user');
-        return $this->client->run();
+        $raw = $this->client->run();
+        $data = json_decode($raw, true);
+        if (isset($data['choices'][0]['message']['content'])) {
+            return trim($data['choices'][0]['message']['content']);
+        }
+        return $raw;
     }
 }


### PR DESCRIPTION
## Summary
- parse DeepSeek API JSON response to extract the summary text
- use `DeepseekService` in SummarizeCommand
- add a new ForceSummarizeCommand to include already processed messages
- provide repository method for fetching all messages

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688b953b3fec832280b9b2e2d1131e78