### PR TITLE
Fix Markdown rendering for bullet lists

### DIFF
--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -17,7 +17,8 @@ class TextUtils
 
     public static function escapeMarkdown(string $text): string
     {
-        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'];
+        // Do not escape '-' or '.' to allow proper Markdown bullet and numbered lists
+        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '=', '|', '{', '}', '!'];
         foreach ($special as $char) {
             $text = str_replace($char, '\\' . $char, $text);
         }


### PR DESCRIPTION
## Summary
- allow Telegram summaries to render bullet lists and numbered lists

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_688b989a2ffc8322800d657513c2fe9d