### PR TITLE
Initialize Telegram API before sending messages

### DIFF
--- a/src/Service/TelegramService.php
+++ b/src/Service/TelegramService.php
@@ -5,6 +5,8 @@ namespace Src\Service;
 
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
+use Longman\TelegramBot\Telegram;
+use Src\Config\Config;
 use Psr\Log\LoggerInterface;
 use Src\Service\LoggerService;
 
@@ -15,6 +17,17 @@ class TelegramService
     public function __construct()
     {
         $this->logger = LoggerService::getLogger();
+
+        try {
+            new Telegram(
+                Config::get('TELEGRAM_BOT_TOKEN'),
+                Config::get('TELEGRAM_BOT_NAME')
+            );
+        } catch (TelegramException $e) {
+            // Log initialization failure but allow execution to continue so
+            // sendMessage() will fail gracefully and log the error there.
+            $this->logger->error('Telegram init failed: ' . $e->getMessage());
+        }
     }
 
     public function sendMessage(int $chatId, string $text): void


### PR DESCRIPTION
## Summary
- initialize Longman Request with a Telegram instance in `TelegramService`

## Testing
- `composer exec -- phpunit --configuration phpunit.xml tests`

------
https://chatgpt.com/codex/tasks/task_e_688b9a50ad7483229a5f6fd152c2495e