### PR TITLE
feat: add chunked summarization

### DIFF
--- a/src/Util/TokenCounter.php
+++ b/src/Util/TokenCounter.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Util;
+
+/**
+ * Lightweight token counter.
+ *
+ * We do not need exact token counts, only a rough estimate to
+ * split long transcripts into smaller chunks. We approximate
+ * the number of tokens by dividing the character length by four,
+ * which roughly matches the average token size for English text.
+ */
+class TokenCounter
+{
+    public static function count(string $text): int
+    {
+        // mb_strlen handles multibyte characters safely.
+        return (int) ceil(mb_strlen($text, 'UTF-8') / 4);
+    }
+}


### PR DESCRIPTION
## Summary
- split long chat transcripts into ~3000 token chunks using a lightweight TokenCounter
- summarise each chunk with a minimal prompt and merge summaries in a final global pass

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688c8d67976883229c660e0a95bf8da4