### PR TITLE
Slim down final summary prompt

### DIFF
--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Src\Service\DeepseekService;
+
+class DeepseekServiceTest extends TestCase
+{
+    public function testJsonToMarkdown(): void
+    {
+        $service = new DeepseekService('key');
+        $data = [
+            'participants' => ['Алиса — разработчик'],
+            'topics' => ['Обсуждали релиз'],
+            'issues' => ['Сервер лежал'],
+            'decisions' => ['Исправить баг'],
+        ];
+
+        $ref = new ReflectionClass(DeepseekService::class);
+        $method = $ref->getMethod('jsonToMarkdown');
+        $method->setAccessible(true);
+
+        $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
+
+        $this->assertStringContainsString('# Сводка чата', $md);
+        $this->assertStringContainsString('1. 👥  Участники', $md);
+        $this->assertStringContainsString('Алиса — разработчик', $md);
+    }
+}


### PR DESCRIPTION
## Summary
- Rebuild summary prompt using ChatSummariser-v2 spec to produce Russian JSON with participants, topics, issues and decisions.
- Render four-section Markdown report from the model JSON output.
- Update unit test for the new schema.

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688c935f10608322ab345b6b5245245d