### PR TITLE
Escape Markdown hyphens and prevent Telegram log loops

### DIFF
--- a/src/Service/TelegramLogHandler.php
+++ b/src/Service/TelegramLogHandler.php
@@ -6,6 +6,7 @@ namespace Src\Service;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Monolog\LogRecord;
+use Psr\Log\NullLogger;
 
 class TelegramLogHandler extends AbstractProcessingHandler
 {
@@ -15,13 +16,13 @@ class TelegramLogHandler extends AbstractProcessingHandler
     public function __construct(int $chatId, int $level = Logger::INFO, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
-        $this->telegram = new TelegramService();
+        $this->telegram = new TelegramService(new NullLogger());
         $this->chatId = $chatId;
     }
 
     protected function write(LogRecord $record): void
     {
         $message = sprintf("%s: %s", $record->level->getName(), $record->message);
-        $this->telegram->sendMessage($this->chatId, $message);
+        $this->telegram->sendMessage($this->chatId, $message, '');
     }
 }

--- a/src/Service/TelegramService.php
+++ b/src/Service/TelegramService.php
@@ -15,9 +15,9 @@ class TelegramService
 {
     private LoggerInterface $logger;
 
-    public function __construct()
+    public function __construct(?LoggerInterface $logger = null)
     {
-        $this->logger = LoggerService::getLogger();
+        $this->logger = $logger ?? LoggerService::getLogger();
 
         try {
             new Telegram(
@@ -47,12 +47,16 @@ class TelegramService
         for ($offset = 0; $offset < $length; $offset += $maxLength) {
             $chunk = mb_substr($text, $offset, $maxLength);
 
+            $params = [
+                'chat_id' => $chatId,
+                'text' => $chunk,
+            ];
+            if ($parseMode !== '') {
+                $params['parse_mode'] = $parseMode;
+            }
+
             try {
-                $response = Request::sendMessage([
-                    'chat_id' => $chatId,
-                    'text' => $chunk,
-                    'parse_mode' => $parseMode,
-                ]);
+                $response = Request::sendMessage($params);
 
                 if ($response->isOk()) {
                     $this->logger->info('Sent message to Telegram', ['chat_id' => $chatId]);

--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -31,11 +31,12 @@ class TextUtils
 
     public static function escapeMarkdown(string $text): string
     {
-        // Do not escape '-' or '.' to allow proper Markdown bullet and numbered lists
-        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '=', '|', '{', '}', '!'];
+        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '!'];
         foreach ($special as $char) {
             $text = str_replace($char, '\\' . $char, $text);
         }
+        // allow bullet lists: unescape hyphen at line start followed by space
+        $text = preg_replace('/(^|\n)\\\\-\s/', '$1- ', $text);
         return $text;
     }
 }

--- a/tests/TextUtilsTest.php
+++ b/tests/TextUtilsTest.php
@@ -16,4 +16,11 @@ class TextUtilsTest extends TestCase
         $this->assertStringNotContainsString('Photo ·', $cleaned);
         $this->assertStringContainsString('[foo @ 00:00] hello', $cleaned);
     }
+
+    public function testEscapeMarkdownHandlesHyphens(): void
+    {
+        $input = "Line with hyphen - dash\n- bullet item";
+        $expected = "Line with hyphen \\- dash\n- bullet item";
+        $this->assertSame($expected, TextUtils::escapeMarkdown($input));
+    }
 }


### PR DESCRIPTION
## Summary
- escape hyphen characters in Markdown summaries while keeping bullet lists intact
- avoid recursive Telegram logging by using a NullLogger in TelegramLogHandler
- allow TelegramService to inject custom loggers and skip parse mode when unset
- test Markdown escaping of hyphens

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688cd80f81dc8322bb0fde0723b94074