### PR TITLE
Mark active conversations in daily reports

### DIFF
--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -248,6 +248,15 @@ PROMPT;
         return implode("\n", $lines);
     }
 
+    public function summarizeTopic(string $transcript, string $chatTitle = '', int $chatId = 0): string
+    {
+        $client = $this->client();
+        $prompt = "Summarize in no more than 12 words what the chat messages are about:\n" . $transcript;
+        $client->setTemperature(0.2)->query($prompt, 'user');
+        $raw = $this->runWithRetries($client);
+        return trim($this->extractContent($raw));
+    }
+
     public function summarize(
         string $transcript,
         string $chatTitle = '',


### PR DESCRIPTION
## Summary
- flag chats with messages within the last hour as "active" and append topic info to the report
- add Deepseek `summarizeTopic` helper for short conversation descriptions
- cover active conversation flow with unit tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688cdc4f25d08322a6c6f587c8f0a95d