### PR TITLE
Escape periods in Telegram MarkdownV2 messages

### DIFF
--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -31,7 +31,7 @@ class TextUtils
 
     public static function escapeMarkdown(string $text): string
     {
-        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '!'];
+        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'];
         foreach ($special as $char) {
             $text = str_replace($char, '\\' . $char, $text);
         }

--- a/tests/TextUtilsTest.php
+++ b/tests/TextUtilsTest.php
@@ -23,4 +23,11 @@ class TextUtilsTest extends TestCase
         $expected = "Line with hyphen \\- dash\n- bullet item";
         $this->assertSame($expected, TextUtils::escapeMarkdown($input));
     }
+
+    public function testEscapeMarkdownEscapesDots(): void
+    {
+        $input = "Sentence one. Sentence two.";
+        $expected = "Sentence one\\. Sentence two\\.";
+        $this->assertSame($expected, TextUtils::escapeMarkdown($input));
+    }
 }


### PR DESCRIPTION
## Summary
- handle periods as special characters in MarkdownV2
- add regression test for dot escaping

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688ce0c5d4d08322821e442c73c4d1e2