### PR TITLE
Add employee derivation service

### DIFF
--- a/src/Service/EmployeeService.php
+++ b/src/Service/EmployeeService.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Service;
+
+class EmployeeService
+{
+    /**
+     * Manual list of our employees that don't have "AIO" in their nickname.
+     * Usernames should be stored without leading '@' and in lowercase.
+     */
+    private const MANUAL_EMPLOYEES = [
+        'vdevt',
+        'meowmeat',
+        'nik_sre',
+    ];
+
+    /**
+     * Derive our employees from the list of client employees.
+     *
+     * Each employee should be represented as an associative array containing
+     * at least the keys 'username' and 'nickname'. The check is done
+     * case-insensitively.
+     *
+     * @param array<int,array<string,string>> $clientEmployees
+     * @return array<int,array<string,string>> our employees extracted from the input
+     */
+    public static function deriveOurEmployees(array $clientEmployees): array
+    {
+        $ourEmployees = [];
+        foreach ($clientEmployees as $employee) {
+            $nickname = $employee['nickname'] ?? '';
+            $username = $employee['username'] ?? '';
+            $username = ltrim($username, '@');
+
+            if (stripos($nickname, 'AIO') !== false) {
+                $ourEmployees[] = $employee;
+                continue;
+            }
+
+            if (in_array(strtolower($username), self::MANUAL_EMPLOYEES, true)) {
+                $ourEmployees[] = $employee;
+            }
+        }
+
+        return $ourEmployees;
+    }
+}

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -26,4 +26,19 @@ class DeepseekServiceTest extends TestCase
         $this->assertStringContainsString('1. 👥  Участники', $md);
         $this->assertStringContainsString('Алиса — разработчик', $md);
     }
+
+    public function testExtractEmployeeContext(): void
+    {
+        $service = new DeepseekService('key');
+        $transcript = "[AIOTom @ 09:00] hi\n[vdevt @ 09:05] hi\n[client @ 09:10] yo";
+
+        $ref = new ReflectionClass(DeepseekService::class);
+        $method = $ref->getMethod('extractEmployeeContext');
+        $method->setAccessible(true);
+
+        [$our, $clients] = $method->invoke($service, $transcript);
+
+        $this->assertSame(['AIOTom', 'vdevt'], $our);
+        $this->assertSame(['client'], $clients);
+    }
 }

--- a/tests/EmployeeServiceTest.php
+++ b/tests/EmployeeServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Src\Service\EmployeeService;
+
+class EmployeeServiceTest extends TestCase
+{
+    public function testDerivesOurEmployees(): void
+    {
+        $input = [
+            ['username' => 'client1', 'nickname' => 'Client Person'],
+            ['username' => 'vdevt', 'nickname' => 'Vlad'],
+            ['username' => 'other', 'nickname' => 'Developer AIO'],
+        ];
+
+        $expected = [
+            ['username' => 'vdevt', 'nickname' => 'Vlad'],
+            ['username' => 'other', 'nickname' => 'Developer AIO'],
+        ];
+
+        $this->assertSame($expected, EmployeeService::deriveOurEmployees($input));
+    }
+
+    public function testHandlesCaseInsAndLeadingAt(): void
+    {
+        $input = [
+            ['username' => '@nik_sre', 'nickname' => 'Nick'],
+            ['username' => 'user', 'nickname' => 'lover of aio'],
+            ['username' => 'random', 'nickname' => 'Client'],
+        ];
+
+        $expected = [
+            ['username' => '@nik_sre', 'nickname' => 'Nick'],
+            ['username' => 'user', 'nickname' => 'lover of aio'],
+        ];
+
+        $this->assertSame($expected, EmployeeService::deriveOurEmployees($input));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EmployeeService` to detect our employees based on nickname or manual username list
- feed employee and client participant context into Deepseek summaries for better reports
- cover employee derivation and Deepseek participant parsing with unit tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688ce38df7088322b04e9971d51d1d79