### PR TITLE
Format Telegram summary output

### DIFF
--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -279,10 +279,10 @@ PROMPT;
                 $items = [$items];
             }
             if (!is_array($items) || empty($items)) {
-                $lines[] = '   * Нет';
+                $lines[] = '  - Нет';
             } else {
                 foreach ($items as $item) {
-                    $lines[] = '   * ' . $item;
+                    $lines[] = '  - ' . $item;
                 }
             }
             $lines[] = '';

--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -35,8 +35,8 @@ class TextUtils
         foreach ($special as $char) {
             $text = str_replace($char, '\\' . $char, $text);
         }
-        // allow bullet lists: unescape hyphen at line start followed by space
-        $text = preg_replace('/(^|\n)\\\\-\s/', '$1- ', $text);
+        // allow bullet lists: unescape hyphen at line start (optionally indented)
+        $text = preg_replace('/(^|\n)(\s*)\\\\-\s/', '$1$2- ', $text);
         return $text;
     }
 }

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -24,7 +24,7 @@ class DeepseekServiceTest extends TestCase
 
         $this->assertStringContainsString('# Сводка чата', $md);
         $this->assertStringContainsString('1. 👥  Участники', $md);
-        $this->assertStringContainsString('Алиса — разработчик', $md);
+        $this->assertStringContainsString("  - Алиса — разработчик", $md);
     }
 
     public function testExtractEmployeeContext(): void


### PR DESCRIPTION
## Summary
- improve summary Markdown output for Telegram by switching to hyphen bullets
- adjust markdown escaping to preserve indented lists
- update tests for new bullet formatting

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688ce8a9db648322b377e25bbc9f404b