### PR TITLE
chore: type loggers and fix config test

### DIFF
--- a/src/Commands/SystemCommands/GenericmessageCommand.php
+++ b/src/Commands/SystemCommands/GenericmessageCommand.php
@@ -6,17 +6,18 @@ namespace Src\Commands\SystemCommands;
 use Longman\TelegramBot\Commands\SystemCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Request;
-use Src\Repository\DbalMessageRepository;
-use Src\Service\LoggerService;
-use Src\Service\Database;
+use Psr\Log\LoggerInterface;
 use Src\Logger\MessageLogger;
+use Src\Repository\DbalMessageRepository;
+use Src\Service\Database;
+use Src\Service\LoggerService;
 
 class GenericmessageCommand extends SystemCommand
 {
     protected $name = 'genericmessage';
     protected $description = 'Handles every incoming message';
     protected $version = '1.0.0';
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(...$args)
     {

--- a/src/Commands/UserCommands/ForceSummarizeCommand.php
+++ b/src/Commands/UserCommands/ForceSummarizeCommand.php
@@ -6,13 +6,14 @@ namespace Src\Commands\UserCommands;
 use Longman\TelegramBot\Commands\UserCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Entities\Keyboard;
+use Psr\Log\LoggerInterface;
 use Src\Config\Config;
 use Src\Repository\DbalMessageRepository;
 use Src\Service\Database;
-use Src\Service\LoggerService;
 use Src\Service\DeepseekService;
-use Src\Util\TextUtils;
+use Src\Service\LoggerService;
 use Src\Service\TelegramService;
+use Src\Util\TextUtils;
 
 class ForceSummarizeCommand extends UserCommand
 {
@@ -20,7 +21,7 @@ class ForceSummarizeCommand extends UserCommand
     protected $description = 'Summarize chat ignoring processed flag';
     protected $usage = '/forcesummarize';
     protected $version = '1.0.0';
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(...$args)
     {

--- a/src/Commands/UserCommands/StartCommand.php
+++ b/src/Commands/UserCommands/StartCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Src\Commands\UserCommands;
 
@@ -7,6 +8,7 @@ use Longman\TelegramBot\Commands\UserCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
+use Psr\Log\LoggerInterface;
 use Src\Service\LoggerService;
 
 /**
@@ -20,12 +22,12 @@ class StartCommand extends UserCommand
     protected $description = 'Start command';
     protected $usage = '/start';
     protected $version = '1.0.0';
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(...$args)
     {
         parent::__construct(...$args);
-        $this->logger = \Src\Service\LoggerService::getLogger();
+        $this->logger = LoggerService::getLogger();
     }
 
     /**

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -3,16 +3,17 @@ declare(strict_types=1);
 
 namespace Src\Commands\UserCommands;
 
-use Src\Service\DeepseekService;
 use Longman\TelegramBot\Commands\UserCommand;
-use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Entities\Keyboard;
+use Longman\TelegramBot\Entities\ServerResponse;
+use Psr\Log\LoggerInterface;
 use Src\Config\Config;
 use Src\Repository\DbalMessageRepository;
-use Src\Service\LoggerService;
 use Src\Service\Database;
-use Src\Util\TextUtils;
+use Src\Service\DeepseekService;
+use Src\Service\LoggerService;
 use Src\Service\TelegramService;
+use Src\Util\TextUtils;
 
 class SummarizeCommand extends UserCommand
 {
@@ -20,7 +21,7 @@ class SummarizeCommand extends UserCommand
     protected $description = 'On‑demand summary of today’s chat';
     protected $usage = '/summarize';
     protected $version = '1.0.0';
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(...$args)
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -28,7 +28,7 @@ class ConfigTest extends TestCase
         $ref = new ReflectionClass(Database::class);
         $prop = $ref->getProperty('connection');
         $prop->setAccessible(true);
-        $prop->setValue(null);
+        $prop->setValue(null, null);
 
         $conn = Database::getConnection(new NullLogger());
         $conn->executeStatement('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)');


### PR DESCRIPTION
## Summary
- type-annotate logger properties in commands
- enable strict types in StartCommand
- fix deprecated ReflectionProperty::setValue usage

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688ceb5f17b88322a92d4da7cd120e15