### PR TITLE
Format summaries for Telegram

### DIFF
--- a/src/Commands/UserCommands/ForceSummarizeCommand.php
+++ b/src/Commands/UserCommands/ForceSummarizeCommand.php
@@ -68,7 +68,12 @@ class ForceSummarizeCommand extends UserCommand
         $cleaned = TextUtils::cleanTranscript($raw);
         $deepseek = new DeepseekService(Config::get('DEEPSEEK_API_KEY'));
         $chatTitle = $repo->getChatTitle($targetId);
-        $summary = $deepseek->summarize($cleaned, $chatTitle, $targetId, date('Y-m-d', $dayTs));
+        $dateStr  = date('Y-m-d', $dayTs);
+        $summary   = $deepseek->summarize($cleaned, $chatTitle, $targetId, $dateStr);
+        $json      = json_decode($summary, true);
+        if (is_array($json)) {
+            $summary = $deepseek->jsonToMarkdown($json, $chatTitle, $targetId, $dateStr);
+        }
         $this->logger->info('Force summary generated', ['chat_id' => $targetId]);
 
         $telegram = new TelegramService();

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -68,9 +68,14 @@ class SummarizeCommand extends UserCommand
         $cleaned = TextUtils::cleanTranscript($raw);
         $deepseek = new DeepseekService(Config::get('DEEPSEEK_API_KEY'));
         $chatTitle = $repo->getChatTitle($targetId);
+        $dateStr  = date('Y-m-d', $dayTs);
         try {
-            $summary = $deepseek->summarize($cleaned, $chatTitle, $targetId, date('Y-m-d', $dayTs));
+            $summary = $deepseek->summarize($cleaned, $chatTitle, $targetId, $dateStr);
             $this->logger->info('Summary generated', ['chat_id' => $targetId]);
+            $json = json_decode($summary, true);
+            if (is_array($json)) {
+                $summary = $deepseek->jsonToMarkdown($json, $chatTitle, $targetId, $dateStr);
+            }
         } catch (\Throwable $e) {
             $this->logger->error('Summary generation failed', [
                 'chat_id' => $targetId,

--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -254,7 +254,7 @@ PROMPT;
         return $this->jsonToMarkdown($json, $chatTitle, $chatId, $date);
     }
 
-    private function jsonToMarkdown(array $data, string $chatTitle, int $chatId, string $date): string
+    public function jsonToMarkdown(array $data, string $chatTitle, int $chatId, string $date): string
     {
         $sections = [
             ['emoji' => '👥', 'title' => 'Участники', 'key' => 'participants'],


### PR DESCRIPTION
## Summary
- Render JSON summaries from Deepseek as human-readable Markdown before posting to Telegram
- Allow commands to reuse `DeepseekService::jsonToMarkdown`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688cebc1cf24832288205c95a367379b