### PR TITLE
Fix Markdown hyphen escaping to prevent Telegram parse errors

### DIFF
--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -36,7 +36,7 @@ class TextUtils
             $text = str_replace($char, '\\' . $char, $text);
         }
         // allow bullet lists: unescape hyphen at line start (optionally indented)
-        $text = preg_replace('/(^|\n)(\s*)\\\\-\s/', '$1$2- ', $text);
+        $text = preg_replace('/(^|\n)(\s*)\\\\-\s+(?=\S)/', '$1$2- ', $text);
         return $text;
     }
 }

--- a/tests/TextUtilsTest.php
+++ b/tests/TextUtilsTest.php
@@ -24,6 +24,13 @@ class TextUtilsTest extends TestCase
         $this->assertSame($expected, TextUtils::escapeMarkdown($input));
     }
 
+    public function testEscapeMarkdownDoesNotUnescapeDanglingHyphen(): void
+    {
+        $input = '- ';
+        $expected = '\- ';
+        $this->assertSame($expected, TextUtils::escapeMarkdown($input));
+    }
+
     public function testEscapeMarkdownEscapesDots(): void
     {
         $input = "Sentence one. Sentence two.";


### PR DESCRIPTION
## Summary
- prevent hyphens without text from being treated as Markdown list items
- add regression test for dangling hyphen behavior

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688cf8f3c5f48322b0e28f7031098e04