### PR TITLE
fix: avoid Markdown hyphen parse error

### DIFF
--- a/src/Commands/UserCommands/ForceSummarizeCommand.php
+++ b/src/Commands/UserCommands/ForceSummarizeCommand.php
@@ -84,7 +84,7 @@ class ForceSummarizeCommand extends UserCommand
         $telegram = new TelegramService();
         $response = $telegram->sendMessage(
             $chatId,
-            "*Chat Summary:*\n" . TextUtils::escapeMarkdown($summary),
+            "*Chat Summary:*\n\n" . TextUtils::escapeMarkdown($summary),
             'MarkdownV2'
         );
         if ($response->isOk()) {

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -96,7 +96,7 @@ class SummarizeCommand extends UserCommand
         $telegram = new TelegramService();
         $response = $telegram->sendMessage(
             $chatId,
-            "*Chat Summary:*\n" . TextUtils::escapeMarkdown($summary),
+            "*Chat Summary:*\n\n" . TextUtils::escapeMarkdown($summary),
             'MarkdownV2'
         );
         if ($response->isOk()) {


### PR DESCRIPTION
## Summary
- ensure summary header is separated from list content to prevent Markdown parsing errors

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688cfbe378e08322bbf658d3caf2447f