### PR TITLE
Escape hyphens for Telegram MarkdownV2

### DIFF
--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -35,8 +35,6 @@ class TextUtils
         foreach ($special as $char) {
             $text = str_replace($char, '\\' . $char, $text);
         }
-        // allow bullet lists: unescape hyphen at line start (optionally indented)
-        $text = preg_replace('/(^|\n)(\s*)\\\\-\s+(?=\S)/', '$1$2- ', $text);
         return $text;
     }
 }

--- a/tests/TextUtilsTest.php
+++ b/tests/TextUtilsTest.php
@@ -20,7 +20,7 @@ class TextUtilsTest extends TestCase
     public function testEscapeMarkdownHandlesHyphens(): void
     {
         $input = "Line with hyphen - dash\n- bullet item";
-        $expected = "Line with hyphen \\- dash\n- bullet item";
+        $expected = "Line with hyphen \\- dash\n\\- bullet item";
         $this->assertSame($expected, TextUtils::escapeMarkdown($input));
     }
 


### PR DESCRIPTION
## Summary
- escape all hyphens in Markdown text to prevent Telegram parsing errors
- update tests for new escaping behavior

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688d01a201108322a970c7cea8536a36