### PR TITLE
Make /summarize output concise and Russian

### DIFF
--- a/src/Commands/UserCommands/ForceSummarizeCommand.php
+++ b/src/Commands/UserCommands/ForceSummarizeCommand.php
@@ -84,7 +84,7 @@ class ForceSummarizeCommand extends UserCommand
         $telegram = new TelegramService();
         $response = $telegram->sendMessage(
             $chatId,
-            "*Chat Summary:*\n\n" . TextUtils::escapeMarkdown($summary),
+            TextUtils::escapeMarkdown($summary),
             'MarkdownV2'
         );
         if ($response->isOk()) {

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -96,7 +96,7 @@ class SummarizeCommand extends UserCommand
         $telegram = new TelegramService();
         $response = $telegram->sendMessage(
             $chatId,
-            "*Chat Summary:*\n\n" . TextUtils::escapeMarkdown($summary),
+            TextUtils::escapeMarkdown($summary),
             'MarkdownV2'
         );
         if ($response->isOk()) {

--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -286,30 +286,20 @@ PROMPT;
             ['emoji' => '❓', 'title' => 'Вопросы', 'key' => 'questions'],
         ];
 
-        $lines = [];
-        $lines[] = '# Сводка чата';
-        $lines[] = '';
-        $lines[] = "Chat: {$chatTitle} (ID {$chatId})";
-        $lines[] = "Date: {$date}";
-        $lines[] = '';
+        $lines   = [];
+        $lines[] = "Сводка чата: {$chatTitle} (ID {$chatId}) — {$date}";
 
-        $num = 1;
         foreach ($sections as $section) {
-            $lines[] = sprintf('%d. %s  %s', $num, $section['emoji'], $section['title']);
-            $lines[] = '';
             $items = $data[$section['key']] ?? [];
             if (is_string($items)) {
                 $items = [$items];
             }
             if (!is_array($items) || empty($items)) {
-                $lines[] = '  - Нет';
+                $content = 'Нет';
             } else {
-                foreach ($items as $item) {
-                    $lines[] = '  - ' . $item;
-                }
+                $content = implode('; ', $items);
             }
-            $lines[] = '';
-            $num++;
+            $lines[] = sprintf('%s %s: %s', $section['emoji'], $section['title'], $content);
         }
 
         return implode("\n", $lines);

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -22,9 +22,8 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('# Сводка чата', $md);
-        $this->assertStringContainsString('1. 👥  Участники', $md);
-        $this->assertStringContainsString("  - Алиса — разработчик", $md);
+        $this->assertStringContainsString('Сводка чата: Chat (ID 1) — 2025-01-01', $md);
+        $this->assertStringContainsString('👥 Участники: Алиса — разработчик', $md);
     }
 
     public function testJsonToMarkdownHandlesExtraSections(): void
@@ -40,8 +39,7 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('📌  Действия', $md);
-        $this->assertStringContainsString('  - Позвонить клиенту', $md);
+        $this->assertStringContainsString('📌 Действия: Позвонить клиенту', $md);
     }
 
     public function testDecodeJsonHandlesCodeBlock(): void


### PR DESCRIPTION
## Summary
- streamline chat summary format to single-line Russian bullet sections for quicker reading
- drop extra English heading when posting summaries
- adjust tests for the new condensed report style

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68905f119aa483228b07d1ddaa7d9b2a