### PR TITLE
Format chat summaries as markdown lists

### DIFF
--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -276,27 +276,72 @@ PROMPT;
     public function jsonToMarkdown(array $data, string $chatTitle, int $chatId, string $date): string
     {
 
-        $sections = [
-            ['emoji' => '💬', 'title' => 'Темы', 'key' => 'topics'],
-            ['emoji' => '⚠️', 'title' => 'Проблемы', 'key' => 'issues'],
-            ['emoji' => '✅', 'title' => 'Решения', 'key' => 'decisions'],
-            ['emoji' => '👥', 'title' => 'Участники', 'key' => 'participants'],
+        $baseSections = [
+            'topics'       => 'Темы',
+            'issues'       => 'Проблемы',
+            'decisions'    => 'Решения',
+            'participants' => 'Участники',
+        ];
+        $extraSections = [
+            'actions'      => 'Действия',
         ];
 
         $lines   = [];
-        $lines[] = "Сводка по чату: {$chatTitle} (ID {$chatId}) — {$date}";
+        $lines[] = "- **{$chatTitle} (ID {$chatId})** — {$date}";
 
-        foreach ($sections as $section) {
-            $items = $data[$section['key']] ?? [];
+        foreach ($baseSections as $key => $title) {
+            $items = $data[$key] ?? [];
             if (is_string($items)) {
                 $items = [$items];
             }
+
+            $lines[] = "  - **{$title}**";
+
             if (!is_array($items) || empty($items)) {
-                $content = 'Нет';
+                $lines[] = '    - Нет';
             } else {
-                $content = implode('; ', $items);
+                foreach ($items as $item) {
+                    $lines[] = '    - ' . $item;
+                }
             }
-            $lines[] = sprintf('%s %s: %s', $section['emoji'], $section['title'], $content);
+        }
+
+        foreach ($extraSections as $key => $title) {
+            if (!array_key_exists($key, $data)) {
+                continue;
+            }
+            $items = $data[$key];
+            if (is_string($items)) {
+                $items = [$items];
+            }
+            $lines[] = "  - **{$title}**";
+            if (!is_array($items) || empty($items)) {
+                $lines[] = '    - Нет';
+            } else {
+                foreach ($items as $item) {
+                    $lines[] = '    - ' . $item;
+                }
+            }
+        }
+
+        // Append any unknown sections to keep output deterministic
+        $handled = array_merge(array_keys($baseSections), array_keys($extraSections));
+        foreach ($data as $key => $items) {
+            if (in_array($key, $handled, true)) {
+                continue;
+            }
+            if (is_string($items)) {
+                $items = [$items];
+            }
+            $title = ucfirst($key);
+            $lines[] = "  - **{$title}**";
+            if (!is_array($items) || empty($items)) {
+                $lines[] = '    - Нет';
+            } else {
+                foreach ($items as $item) {
+                    $lines[] = '    - ' . $item;
+                }
+            }
         }
 
         return implode("\n", $lines);

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -22,8 +22,9 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('Сводка чата: Chat (ID 1) — 2025-01-01', $md);
-        $this->assertStringContainsString('👥 Участники: Алиса — разработчик', $md);
+        $this->assertStringContainsString('- **Chat (ID 1)** — 2025-01-01', $md);
+        $this->assertStringContainsString('  - **Участники**', $md);
+        $this->assertStringContainsString('    - Алиса — разработчик', $md);
     }
 
     public function testJsonToMarkdownHandlesExtraSections(): void
@@ -39,7 +40,8 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('📌 Действия: Позвонить клиенту', $md);
+        $this->assertStringContainsString('  - **Действия**', $md);
+        $this->assertStringContainsString('    - Позвонить клиенту', $md);
     }
 
     public function testDecodeJsonHandlesCodeBlock(): void


### PR DESCRIPTION
## Summary
- format generated summaries as nested markdown bullet lists
- support optional sections like actions while appending unknown keys
- update unit tests for new markdown list structure

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6890689d80d483228ccc0e06adac0990