### PR TITLE
Use telegramify-markdown escaping

### DIFF
--- a/src/Commands/UserCommands/ForceSummarizeCommand.php
+++ b/src/Commands/UserCommands/ForceSummarizeCommand.php
@@ -84,7 +84,7 @@ class ForceSummarizeCommand extends UserCommand
         $telegram = new TelegramService();
         $response = $telegram->sendMessage(
             $chatId,
-            TextUtils::escapeMarkdown($summary),
+            $summary,
             'MarkdownV2'
         );
         if ($response->isOk()) {

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -94,7 +94,7 @@ class SummarizeCommand extends UserCommand
         $telegram = new TelegramService();
         $response = $telegram->sendMessage(
             $chatId,
-            TextUtils::escapeMarkdown($summary),
+            $summary,
             'MarkdownV2'
         );
         if ($response->isOk()) {

--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -29,12 +29,27 @@ class TextUtils
         );
     }
 
+    /**
+     * Escape a string for safe use with Telegram MarkdownV2.
+     *
+     * Ported from the telegramify-markdown project to ensure proper
+     * escaping without double-escaping already escaped characters.
+     * @see https://github.com/sudoskys/telegramify-markdown
+     */
     public static function escapeMarkdown(string $text): string
     {
-        $special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'];
-        foreach ($special as $char) {
-            $text = str_replace($char, '\\' . $char, $text);
+        if ($text === '') {
+            return '';
         }
-        return $text;
+
+        // Convert HTML entities back to characters before escaping
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // First pass: escape all special MarkdownV2 characters
+        $pattern = '/([\\_\*\[\]\(\)~`>\#\+\-\=\|\{\}\.\!])/';
+        $escaped = preg_replace($pattern, "\\\\$1", $text);
+
+        // Second pass: remove double escaping
+        return preg_replace('/\\\\\\\\([\\_\*\[\]\(\)~`>\#\+\-\=\|\{\}\.\!])/', "\\\\$1", $escaped);
     }
 }

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -22,8 +22,8 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('- **Chat (ID 1)** — 2025-01-01', $md);
-        $this->assertStringContainsString('  - **Участники**', $md);
+        $this->assertStringContainsString('- *Chat (ID 1)* — 2025\\-01\\-01', $md);
+        $this->assertStringContainsString('  - *Участники*', $md);
         $this->assertStringContainsString('    - Алиса — разработчик', $md);
     }
 
@@ -40,8 +40,25 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('  - **Действия**', $md);
+        $this->assertStringContainsString('  - *Действия*', $md);
         $this->assertStringContainsString('    - Позвонить клиенту', $md);
+    }
+
+    public function testJsonToMarkdownEscapesValues(): void
+    {
+        $service = new DeepseekService('key');
+        $data = [
+            'topics' => ['Need _attention_ and *fix*'],
+        ];
+
+        $ref = new ReflectionClass(DeepseekService::class);
+        $method = $ref->getMethod('jsonToMarkdown');
+        $method->setAccessible(true);
+
+        $md = $method->invoke($service, $data, 'Chat_', 1, '2025-01-01');
+
+        $this->assertStringContainsString('- *Chat\_ (ID 1)* — 2025\-01\-01', $md);
+        $this->assertStringContainsString('Need \\_attention\\_ and \\*fix\\*', $md);
     }
 
     public function testDecodeJsonHandlesCodeBlock(): void

--- a/tests/TextUtilsTest.php
+++ b/tests/TextUtilsTest.php
@@ -37,4 +37,11 @@ class TextUtilsTest extends TestCase
         $expected = "Sentence one\\. Sentence two\\.";
         $this->assertSame($expected, TextUtils::escapeMarkdown($input));
     }
+
+    public function testEscapeMarkdownPreservesExistingEscapes(): void
+    {
+        $input = '\\_already escaped\\_ and *bold*';
+        $expected = '\\_already escaped\\_ and \\*bold\\*';
+        $this->assertSame($expected, TextUtils::escapeMarkdown($input));
+    }
 }


### PR DESCRIPTION
## Summary
- adopt telegramify-markdown's escaping logic for Telegram MarkdownV2
- add regression test to ensure already escaped sequences remain untouched
- sanitize DeepseekService output and avoid double escaping in summary commands

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68906c721cc08322988505bd16df7883