### PR TITLE
Fix Telegram Markdown hyphen parsing in summaries

### DIFF
--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -290,7 +290,7 @@ PROMPT;
         $lines = [];
         $titleLine = TextUtils::escapeMarkdown($chatTitle);
         $dateLine  = TextUtils::escapeMarkdown($date);
-        $lines[]   = "- *{$titleLine} (ID {$chatId})* — {$dateLine}";
+        $lines[]   = "*{$titleLine} (ID {$chatId})* — {$dateLine}";
 
         foreach ($baseSections as $key => $title) {
             $items = $data[$key] ?? [];
@@ -298,13 +298,13 @@ PROMPT;
                 $items = [$items];
             }
 
-            $lines[] = "  - *{$title}*";
+            $lines[] = "• *{$title}*";
 
             if (!is_array($items) || empty($items)) {
-                $lines[] = '    - Нет';
+                $lines[] = '  • Нет';
             } else {
                 foreach ($items as $item) {
-                    $lines[] = '    - ' . TextUtils::escapeMarkdown((string) $item);
+                    $lines[] = '  • ' . TextUtils::escapeMarkdown((string) $item);
                 }
             }
         }
@@ -317,12 +317,12 @@ PROMPT;
             if (is_string($items)) {
                 $items = [$items];
             }
-            $lines[] = "  - *{$title}*";
+            $lines[] = "• *{$title}*";
             if (!is_array($items) || empty($items)) {
-                $lines[] = '    - Нет';
+                $lines[] = '  • Нет';
             } else {
                 foreach ($items as $item) {
-                    $lines[] = '    - ' . TextUtils::escapeMarkdown((string) $item);
+                    $lines[] = '  • ' . TextUtils::escapeMarkdown((string) $item);
                 }
             }
         }
@@ -337,12 +337,12 @@ PROMPT;
                 $items = [$items];
             }
             $sectionTitle = TextUtils::escapeMarkdown(ucfirst($key));
-            $lines[] = "  - *{$sectionTitle}*";
+            $lines[] = "• *{$sectionTitle}*";
             if (!is_array($items) || empty($items)) {
-                $lines[] = '    - Нет';
+                $lines[] = '  • Нет';
             } else {
                 foreach ($items as $item) {
-                    $lines[] = '    - ' . TextUtils::escapeMarkdown((string) $item);
+                    $lines[] = '  • ' . TextUtils::escapeMarkdown((string) $item);
                 }
             }
         }

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -22,9 +22,9 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('- *Chat (ID 1)* — 2025\\-01\\-01', $md);
-        $this->assertStringContainsString('  - *Участники*', $md);
-        $this->assertStringContainsString('    - Алиса — разработчик', $md);
+        $this->assertStringContainsString('*Chat (ID 1)* — 2025\\-01\\-01', $md);
+        $this->assertStringContainsString('• *Участники*', $md);
+        $this->assertStringContainsString('  • Алиса — разработчик', $md);
     }
 
     public function testJsonToMarkdownHandlesExtraSections(): void
@@ -40,8 +40,8 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('  - *Действия*', $md);
-        $this->assertStringContainsString('    - Позвонить клиенту', $md);
+        $this->assertStringContainsString('• *Действия*', $md);
+        $this->assertStringContainsString('  • Позвонить клиенту', $md);
     }
 
     public function testJsonToMarkdownEscapesValues(): void
@@ -57,7 +57,7 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat_', 1, '2025-01-01');
 
-        $this->assertStringContainsString('- *Chat\_ (ID 1)* — 2025\-01\-01', $md);
+        $this->assertStringContainsString('*Chat\_ (ID 1)* — 2025\-01\-01', $md);
         $this->assertStringContainsString('Need \\_attention\\_ and \\*fix\\*', $md);
     }
 


### PR DESCRIPTION
## Summary
- replace hyphen bullets with bullet character to avoid MarkdownV2 parsing errors
- adjust tests for new bullet formatting

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68908939a94c832289adf11200cdf790