### PR TITLE
refactor: harden DeepSeek integration

### DIFF
--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -73,15 +73,6 @@ class SummarizeCommand extends UserCommand
         try {
             $summary = $deepseek->summarize($cleaned, $chatTitle, $targetId, $dateStr);
             $this->logger->info('Summary generated', ['chat_id' => $targetId]);
-
-            $json = json_decode($summary, true);
-            if (!is_array($json) && preg_match('/{.*}/s', $summary, $m)) {
-                $json = json_decode($m[0], true);
-            }
-            if (is_array($json)) {
-                $summary = $deepseek->jsonToMarkdown($json, $chatTitle, $targetId, $dateStr);
-                $this->logger->info('Summary is valid JSON, decoding', ['summary' => $summary]);
-            }
         } catch (\Throwable $e) {
             $this->logger->error('Summary generation failed', [
                 'chat_id' => $targetId,

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -6,6 +6,12 @@ use Src\Service\DeepseekService;
 
 class DeepseekServiceTest extends TestCase
 {
+    public function testConstructorThrowsOnEmptyApiKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new DeepseekService('');
+    }
+
     public function testJsonToMarkdown(): void
     {
         $service = new DeepseekService('key');


### PR DESCRIPTION
## Summary
- validate DeepSeek API key on creation and add exponential backoff retries
- simplify summarize commands to use DeepSeek output directly and log errors
- cover empty API key handling with unit test

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689096cc59a88322b273f9d5b1696333