### PR TITLE
Improve DeepSeek response parsing and Markdown output

### DIFF
--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -87,10 +87,13 @@ class DeepseekService
         $content = '';
         foreach (preg_split("/\r\n|\n|\r/", trim($raw)) as $line) {
             $line = trim($line);
-            if ($line === '' || !str_starts_with($line, 'data:')) {
+            if ($line === '') {
                 continue;
             }
-            $payload = trim(substr($line, 5));
+            if (!preg_match('/^data:\\s*(.+)$/', $line, $m)) {
+                continue;
+            }
+            $payload = trim($m[1]);
             if ($payload === '' || $payload === '[DONE]') {
                 continue;
             }
@@ -285,6 +288,9 @@ PROMPT;
         ];
         $extraSections = [
             'actions'      => 'Действия',
+            'events'       => 'События',
+            'blockers'     => 'Блокеры',
+            'questions'    => 'Вопросы',
         ];
 
         $lines = [];

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -27,11 +27,14 @@ class DeepseekServiceTest extends TestCase
         $this->assertStringContainsString('  • Алиса — разработчик', $md);
     }
 
-    public function testJsonToMarkdownHandlesExtraSections(): void
+    public function testJsonToMarkdownHandlesOptionalSections(): void
     {
         $service = new DeepseekService('key');
         $data = [
             'actions' => ['Позвонить клиенту'],
+            'events' => ['Обновили сайт'],
+            'blockers' => ['Нет доступа'],
+            'questions' => ['Когда релиз?'],
         ];
 
         $ref = new ReflectionClass(DeepseekService::class);
@@ -42,6 +45,12 @@ class DeepseekServiceTest extends TestCase
 
         $this->assertStringContainsString('• *Действия*', $md);
         $this->assertStringContainsString('  • Позвонить клиенту', $md);
+        $this->assertStringContainsString('• *События*', $md);
+        $this->assertStringContainsString('  • Обновили сайт', $md);
+        $this->assertStringContainsString('• *Блокеры*', $md);
+        $this->assertStringContainsString('  • Нет доступа', $md);
+        $this->assertStringContainsString('• *Вопросы*', $md);
+        $this->assertStringContainsString('  • Когда релиз?', $md);
     }
 
     public function testJsonToMarkdownEscapesValues(): void
@@ -73,6 +82,21 @@ class DeepseekServiceTest extends TestCase
         $json = $method->invoke($service, $content);
 
         $this->assertSame(['a' => 1], $json);
+    }
+
+    public function testExtractContentParsesSse(): void
+    {
+        $service = new DeepseekService('key');
+        $raw = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n" .
+               "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n" .
+               "data: [DONE]\n";
+
+        $ref = new ReflectionClass(DeepseekService::class);
+        $method = $ref->getMethod('extractContent');
+        $method->setAccessible(true);
+
+        $content = $method->invoke($service, $raw);
+        $this->assertSame('Hello world', $content);
     }
 
     public function testExtractEmployeeContext(): void


### PR DESCRIPTION
## Summary
- Improve SSE data parsing in DeepSeek service to handle spaces and ignore non-data lines
- Extend JSON-to-Markdown conversion with events, blockers, and questions sections
- Add unit tests covering SSE parsing and optional summary sections

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689096cc59a88322b273f9d5b1696333