### PR TITLE
Escape Telegram MarkdownV2 messages

### DIFF
--- a/tests/TextUtilsTest.php
+++ b/tests/TextUtilsTest.php
@@ -44,4 +44,11 @@ class TextUtilsTest extends TestCase
         $expected = '\\_already escaped\\_ and \\*bold\\*';
         $this->assertSame($expected, TextUtils::escapeMarkdown($input));
     }
+
+    public function testEscapeMarkdownEscapesParentheses(): void
+    {
+        $input = 'Example (test)';
+        $expected = 'Example \\(test\\)';
+        $this->assertSame($expected, TextUtils::escapeMarkdown($input));
+    }
 }


### PR DESCRIPTION
## Summary
- escape MarkdownV2 content in TelegramService before sending
- test Markdown escaping for parentheses

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6890ba29707c832294e48a7d24b58e76