### PR TITLE
Remove bullets from section headers and fix Markdown

### DIFF
--- a/src/Service/DeepseekService.php
+++ b/src/Service/DeepseekService.php
@@ -300,9 +300,10 @@ PROMPT;
         ];
 
         $lines = [];
-        $titleLine = TextUtils::escapeMarkdown($chatTitle);
-        $dateLine  = TextUtils::escapeMarkdown($date);
-        $lines[]   = "*{$titleLine} (ID {$chatId})* — {$dateLine}";
+        $titleLine  = TextUtils::escapeMarkdown($chatTitle);
+        $dateLine   = TextUtils::escapeMarkdown($date);
+        $chatIdLine = TextUtils::escapeMarkdown((string) $chatId);
+        $lines[]    = "*{$titleLine} (ID {$chatIdLine})* — {$dateLine}";
 
         foreach ($baseSections as $key => $title) {
             $items = $data[$key] ?? [];
@@ -310,7 +311,8 @@ PROMPT;
                 $items = [$items];
             }
 
-            $lines[] = "• *{$title}*";
+            $sectionTitle = TextUtils::escapeMarkdown($title);
+            $lines[]      = "*{$sectionTitle}*";
 
             if (!is_array($items) || empty($items)) {
                 $lines[] = '  • Нет';
@@ -329,7 +331,8 @@ PROMPT;
             if (is_string($items)) {
                 $items = [$items];
             }
-            $lines[] = "• *{$title}*";
+            $sectionTitle = TextUtils::escapeMarkdown($title);
+            $lines[]      = "*{$sectionTitle}*";
             if (!is_array($items) || empty($items)) {
                 $lines[] = '  • Нет';
             } else {
@@ -349,7 +352,7 @@ PROMPT;
                 $items = [$items];
             }
             $sectionTitle = TextUtils::escapeMarkdown(ucfirst($key));
-            $lines[] = "• *{$sectionTitle}*";
+            $lines[]      = "*{$sectionTitle}*";
             if (!is_array($items) || empty($items)) {
                 $lines[] = '  • Нет';
             } else {

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -67,9 +67,10 @@ class ReportService
                     $note = "\n\n⚠️ Active conversation ongoing";
                 }
             }
-            $header = "*Report for chat* `{$chatId}`\n_" . date('Y-m-d', $now) . "_\n\n";
+            $dateLine   = TextUtils::escapeMarkdown(date('Y-m-d', $now));
+            $header     = "*Report for chat* `{$chatId}`\n_{$dateLine}_\n\n";
             $reportText = $header . $summary . $note;
-            $this->telegram->sendMessage($this->summaryChatId, $reportText);
+            $this->telegram->sendMessage($this->summaryChatId, $reportText, 'MarkdownV2');
             if ($this->slack !== null) {
                 $this->slack->sendMessage(strip_tags($reportText));
             }

--- a/src/Service/TelegramService.php
+++ b/src/Service/TelegramService.php
@@ -10,7 +10,6 @@ use Longman\TelegramBot\Telegram;
 use Psr\Log\LoggerInterface;
 use Src\Config\Config;
 use Src\Service\LoggerService;
-use Src\Util\TextUtils;
 
 class TelegramService
 {
@@ -43,10 +42,6 @@ class TelegramService
     {
         $maxLength = 4096;
         $response = Request::emptyResponse();
-
-        if ($parseMode === 'MarkdownV2') {
-            $text = TextUtils::escapeMarkdown($text);
-        }
 
         $length = mb_strlen($text);
         for ($offset = 0; $offset < $length;) {

--- a/tests/DeepseekServiceTest.php
+++ b/tests/DeepseekServiceTest.php
@@ -29,7 +29,7 @@ class DeepseekServiceTest extends TestCase
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
         $this->assertStringContainsString('*Chat (ID 1)* — 2025\\-01\\-01', $md);
-        $this->assertStringContainsString('• *Участники*', $md);
+        $this->assertStringContainsString('*Участники*', $md);
         $this->assertStringContainsString('  • Алиса — разработчик', $md);
     }
 
@@ -49,13 +49,13 @@ class DeepseekServiceTest extends TestCase
 
         $md = $method->invoke($service, $data, 'Chat', 1, '2025-01-01');
 
-        $this->assertStringContainsString('• *Действия*', $md);
+        $this->assertStringContainsString('*Действия*', $md);
         $this->assertStringContainsString('  • Позвонить клиенту', $md);
-        $this->assertStringContainsString('• *События*', $md);
+        $this->assertStringContainsString('*События*', $md);
         $this->assertStringContainsString('  • Обновили сайт', $md);
-        $this->assertStringContainsString('• *Блокеры*', $md);
+        $this->assertStringContainsString('*Блокеры*', $md);
         $this->assertStringContainsString('  • Нет доступа', $md);
-        $this->assertStringContainsString('• *Вопросы*', $md);
+        $this->assertStringContainsString('*Вопросы*', $md);
         $this->assertStringContainsString('  • Когда релиз?', $md);
     }
 

--- a/tests/ReportServiceTest.php
+++ b/tests/ReportServiceTest.php
@@ -50,7 +50,7 @@ class ReportServiceTest extends TestCase
 
         $telegram->expects($this->once())
             ->method('sendMessage')
-            ->with(99, "*Report for chat* `1`\n_" . date('Y-m-d', $run) . "_\n\nsummary");
+            ->with(99, "*Report for chat* `1`\n_" . str_replace('-', '\\-', date('Y-m-d', $run)) . "_\n\nsummary", 'MarkdownV2');
 
         $repo->expects($this->once())
             ->method('markProcessed')
@@ -107,7 +107,7 @@ class ReportServiceTest extends TestCase
 
         $telegram->expects($this->once())
             ->method('sendMessage')
-            ->with(99, $this->stringContains('Active conversation about: topic'));
+            ->with(99, $this->stringContains('Active conversation about: topic'), 'MarkdownV2');
 
         $repo->expects($this->once())
             ->method('markProcessed')


### PR DESCRIPTION
## Summary
- send summary headers without leading bullets and escape IDs for Markdown
- deliver daily reports using MarkdownV2 and escaped dates
- avoid auto-escaping Markdown in TelegramService to preserve formatting

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6890bc4e9f488322abefbb93d80d0810