### PR TITLE
feat: interactive summarize command

### DIFF
--- a/src/Commands/SystemCommands/CallbackqueryCommand.php
+++ b/src/Commands/SystemCommands/CallbackqueryCommand.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Commands\SystemCommands;
+
+use Longman\TelegramBot\Commands\SystemCommand;
+use Longman\TelegramBot\Entities\ServerResponse;
+use Longman\TelegramBot\Entities\InlineKeyboard;
+use Longman\TelegramBot\Request;
+use Psr\Log\LoggerInterface;
+use Src\Config\Config;
+use Src\Repository\DbalMessageRepository;
+use Src\Service\Database;
+use Src\Service\DeepseekService;
+use Src\Service\LoggerService;
+use Src\Service\TelegramService;
+use Src\Util\TextUtils;
+
+class CallbackqueryCommand extends SystemCommand
+{
+    protected $name = 'callbackquery';
+    protected $description = 'Handle callback queries';
+    protected $version = '1.0.0';
+
+    private LoggerInterface $logger;
+
+    public function __construct(...$args)
+    {
+        parent::__construct(...$args);
+        $this->logger = LoggerService::getLogger();
+    }
+
+    public function execute(): ServerResponse
+    {
+        $callback = $this->getCallbackQuery();
+        $data = $callback->getData();
+        $message = $callback->getMessage();
+        $chatId = $message->getChat()->getId();
+
+        $conn = Database::getConnection($this->logger);
+        $repo = new DbalMessageRepository($conn, $this->logger);
+
+        if (strpos($data, 'sum_c_') === 0) {
+            $targetChatId = (int)substr($data, strlen('sum_c_'));
+            $response = $this->sendDateSelector($repo, $chatId, $targetChatId, (int)date('Y'), (int)date('m'), $message->getMessageId());
+            $callback->answer();
+            return $response;
+        }
+
+        if (preg_match('/^sum_m_(\-?\d+)_(\d{4})-(\d{2})_(prev|next)$/', $data, $m)) {
+            $targetChatId = (int)$m[1];
+            $year = (int)$m[2];
+            $month = (int)$m[3];
+            $dir = $m[4];
+            $month += ($dir === 'next') ? 1 : -1;
+            if ($month < 1) {
+                $month = 12;
+                $year--;
+            } elseif ($month > 12) {
+                $month = 1;
+                $year++;
+            }
+            $response = $this->sendDateSelector($repo, $chatId, $targetChatId, $year, $month, $message->getMessageId());
+            $callback->answer();
+            return $response;
+        }
+
+        if (preg_match('/^sum_d_(\-?\d+)_(\d{4}-\d{2}-\d{2})$/', $data, $m)) {
+            $targetChatId = (int)$m[1];
+            $dateStr = $m[2];
+            Request::editMessageReplyMarkup([
+                'chat_id' => $chatId,
+                'message_id' => $message->getMessageId(),
+                'reply_markup' => new InlineKeyboard([]),
+            ]);
+            $response = $this->summarizeChat($repo, $targetChatId, $dateStr, $chatId);
+            $callback->answer();
+            return $response;
+        }
+
+        return $callback->answer();
+    }
+
+    private function sendDateSelector(DbalMessageRepository $repo, int $replyChatId, int $targetChatId, int $year, int $month, int $messageId): ServerResponse
+    {
+        $days = cal_days_in_month(CAL_GREGORIAN, $month, $year);
+        $keyboard = new InlineKeyboard();
+        $row = [];
+        for ($d = 1; $d <= $days; $d++) {
+            $row[] = [
+                'text' => (string)$d,
+                'callback_data' => sprintf('sum_d_%d_%04d-%02d-%02d', $targetChatId, $year, $month, $d),
+            ];
+            if (count($row) === 7) {
+                $keyboard->addRow(...$row);
+                $row = [];
+            }
+        }
+        if (!empty($row)) {
+            $keyboard->addRow(...$row);
+        }
+        $keyboard->addRow(
+            ['text' => 'Prev', 'callback_data' => sprintf('sum_m_%d_%04d-%02d_prev', $targetChatId, $year, $month)],
+            ['text' => 'Next', 'callback_data' => sprintf('sum_m_%d_%04d-%02d_next', $targetChatId, $year, $month)]
+        );
+        $chatTitle = $repo->getChatTitle($targetChatId);
+        $text = sprintf('Select date for %s (%04d-%02d)', $chatTitle, $year, $month);
+
+        return Request::editMessageText([
+            'chat_id' => $replyChatId,
+            'message_id' => $messageId,
+            'text' => $text,
+            'reply_markup' => $keyboard,
+        ]);
+    }
+
+    private function summarizeChat(DbalMessageRepository $repo, int $targetId, string $dateStr, int $replyChatId): ServerResponse
+    {
+        $dayTs = strtotime($dateStr);
+        if ($dayTs === false) {
+            return $this->replyToChat('Invalid date format, use YYYY-MM-DD');
+        }
+
+        $msgs = $repo->getMessagesForChat($targetId, $dayTs);
+        if (empty($msgs)) {
+            return $this->replyToChat('No messages to summarize yet.');
+        }
+
+        $raw = TextUtils::buildTranscript($msgs);
+        $cleaned = TextUtils::cleanTranscript($raw);
+        $deepseek = new DeepseekService(Config::get('DEEPSEEK_API_KEY'));
+        $chatTitle = $repo->getChatTitle($targetId);
+        $dateStr = date('Y-m-d', $dayTs);
+        try {
+            $summary = $deepseek->summarize($cleaned, $chatTitle, $targetId, $dateStr);
+            $this->logger->info('Summary generated', ['chat_id' => $targetId]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Summary generation failed', [
+                'chat_id' => $targetId,
+                'error' => $e->getMessage(),
+            ]);
+            return $this->replyToChat('Failed to generate summary, please try again later.');
+        }
+
+        $repo->markProcessed($targetId, $dayTs);
+        $telegram = new TelegramService($this->logger);
+        $response = $telegram->sendMessage($replyChatId, $summary, 'MarkdownV2');
+        if ($response->isOk()) {
+            $this->logger->info('Summary sent to chat', ['chat_id' => $replyChatId]);
+        } else {
+            $this->logger->error('Failed to send summary', [
+                'chat_id' => $replyChatId,
+                'error' => $response->getDescription(),
+            ]);
+        }
+
+        return $response;
+    }
+}
+

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -4,23 +4,19 @@ declare(strict_types=1);
 namespace Src\Commands\UserCommands;
 
 use Longman\TelegramBot\Commands\UserCommand;
-use Longman\TelegramBot\Entities\Keyboard;
+use Longman\TelegramBot\Entities\InlineKeyboard;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Psr\Log\LoggerInterface;
-use Src\Config\Config;
 use Src\Repository\DbalMessageRepository;
 use Src\Service\Database;
-use Src\Service\DeepseekService;
 use Src\Service\LoggerService;
-use Src\Service\TelegramService;
-use Src\Util\TextUtils;
 
 class SummarizeCommand extends UserCommand
 {
     protected $name = 'summarize';
-    protected $description = 'On‑demand summary of today’s chat';
+    protected $description = 'On‑demand summary of chat';
     protected $usage = '/summarize';
-    protected $version = '1.0.0';
+    protected $version = '1.1.0';
     private LoggerInterface $logger;
 
     public function __construct(...$args)
@@ -33,70 +29,19 @@ class SummarizeCommand extends UserCommand
     {
         $chatId = $this->getMessage()->getChat()->getId();
         $this->logger->info('Summarize command triggered', ['chat_id' => $chatId]);
+
         $conn = Database::getConnection($this->logger);
         $repo = new DbalMessageRepository($conn, $this->logger);
 
-        $params = trim($this->getMessage()->getText(true));
-        if ($params === '') {
-            $buttons = [];
-            foreach ($repo->listChats() as $chat) {
-                $label = trim(($chat['title'] ?? '') . ' (' . $chat['id'] . ')');
-                $buttons[] = [$label];
-            }
-            $keyboard = new Keyboard([
-                'keyboard' => $buttons,
-                'resize_keyboard' => true,
-                'one_time_keyboard' => true,
-            ]);
-            return $this->replyToChat('Send /summarize <chat_id> [YYYY-MM-DD]', [
-                'reply_markup' => $keyboard,
-            ]);
+        $keyboard = new InlineKeyboard();
+        foreach ($repo->listChats() as $chat) {
+            $label = trim(($chat['title'] ?? '') . ' (' . $chat['id'] . ')');
+            $keyboard->addRow(['text' => $label, 'callback_data' => 'sum_c_' . $chat['id']]);
         }
 
-        [$targetId, $dateStr] = array_pad(explode(' ', $params, 2), 2, '');
-        $targetId = (int)$targetId;
-        $dayTs = $dateStr !== '' ? strtotime($dateStr) : time();
-        if ($dayTs === false) {
-            return $this->replyToChat('Invalid date format, use YYYY-MM-DD');
-        }
-
-        $msgs = $repo->getMessagesForChat($targetId, $dayTs);
-        if (empty($msgs)) {
-            return $this->replyToChat('No messages to summarize yet.');
-        }
-
-        $raw = TextUtils::buildTranscript($msgs);
-        $cleaned = TextUtils::cleanTranscript($raw);
-        $deepseek = new DeepseekService(Config::get('DEEPSEEK_API_KEY'));
-        $chatTitle = $repo->getChatTitle($targetId);
-        $dateStr  = date('Y-m-d', $dayTs);
-        try {
-            $summary = $deepseek->summarize($cleaned, $chatTitle, $targetId, $dateStr);
-            $this->logger->info('Summary generated', ['chat_id' => $targetId]);
-        } catch (\Throwable $e) {
-            $this->logger->error('Summary generation failed', [
-                'chat_id' => $targetId,
-                'error' => $e->getMessage(),
-            ]);
-            return $this->replyToChat('Failed to generate summary, please try again later.');
-        }
-
-        $repo->markProcessed($targetId, $dayTs);
-        $telegram = new TelegramService();
-        $response = $telegram->sendMessage(
-            $chatId,
-            $summary,
-            'MarkdownV2'
-        );
-        if ($response->isOk()) {
-            $this->logger->info('Summary sent to chat', ['chat_id' => $chatId]);
-        } else {
-            $this->logger->error('Failed to send summary', [
-                'chat_id' => $chatId,
-                'error' => $response->getDescription(),
-            ]);
-        }
-
-        return $response;
+        return $this->replyToChat('Select chat to summarize:', [
+            'reply_markup' => $keyboard,
+        ]);
     }
 }
+

--- a/src/Service/TelegramService.php
+++ b/src/Service/TelegramService.php
@@ -38,7 +38,7 @@ class TelegramService
      * messages are split into multiple chunks and sent sequentially. The
      * method returns the response of the last chunk sent.
      */
-    public function sendMessage(int $chatId, string $text, string $parseMode = 'Markdown'): ServerResponse
+    public function sendMessage(int $chatId, string $text, string $parseMode = 'Markdown', array $extra = []): ServerResponse
     {
         $maxLength = 4096;
         $response = Request::emptyResponse();
@@ -55,10 +55,10 @@ class TelegramService
                 }
             }
 
-            $params = [
+            $params = array_merge([
                 'chat_id' => $chatId,
-                'text' => $chunk,
-            ];
+                'text'   => $chunk,
+            ], $extra);
             if ($parseMode !== '') {
                 $params['parse_mode'] = $parseMode;
             }


### PR DESCRIPTION
## Summary
- make /summarize command interactive using callback queries for chat and date selection
- allow TelegramService::sendMessage to accept extra params such as reply_markup

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6891c67043a88322b90336641c4d5430