### PR TITLE
Fix inline keyboard initialization

### DIFF
--- a/src/Commands/SystemCommands/CallbackqueryCommand.php
+++ b/src/Commands/SystemCommands/CallbackqueryCommand.php
@@ -84,7 +84,7 @@ class CallbackqueryCommand extends SystemCommand
     private function sendDateSelector(DbalMessageRepository $repo, int $replyChatId, int $targetChatId, int $year, int $month, int $messageId): ServerResponse
     {
         $days = cal_days_in_month(CAL_GREGORIAN, $month, $year);
-        $keyboard = new InlineKeyboard();
+        $keyboard = new InlineKeyboard([]);
         $row = [];
         for ($d = 1; $d <= $days; $d++) {
             $row[] = [

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -35,7 +35,7 @@ class SummarizeCommand extends UserCommand
             $conn = Database::getConnection($this->logger);
             $repo = new DbalMessageRepository($conn, $this->logger);
 
-            $keyboard = new InlineKeyboard();
+            $keyboard = new InlineKeyboard([]);
             $this->logger->info('Creating keyboard', ['chat_id' => $chatId]);
             foreach ($repo->listChats() as $chat) {
                 $label = trim(($chat['title'] ?? '') . ' (' . $chat['id'] . ')');


### PR DESCRIPTION
## Summary
- initialize inline keyboards with empty array to avoid array_filter error

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6891f7b595448322b4abcc875876b041