### PR TITLE
Reduce redundant chat title lookups

### DIFF
--- a/src/Commands/SystemCommands/CallbackqueryCommand.php
+++ b/src/Commands/SystemCommands/CallbackqueryCommand.php
@@ -123,7 +123,8 @@ class CallbackqueryCommand extends SystemCommand
 
         $msgs = $repo->getMessagesForChat($targetId, $dayTs);
         if (empty($msgs)) {
-            return $this->replyToChat('No messages to summarize yet.');
+            $telegram = new TelegramService($this->logger);
+            return $telegram->sendMessage($replyChatId, 'No messages to summarize yet.');
         }
 
         $raw = TextUtils::buildTranscript($msgs);

--- a/src/Repository/DbalMessageRepository.php
+++ b/src/Repository/DbalMessageRepository.php
@@ -8,6 +8,9 @@ use Psr\Log\LoggerInterface;
 
 class DbalMessageRepository implements MessageRepositoryInterface
 {
+    /** @var array<int,string> */
+    private array $titleCache = [];
+
     public function __construct(private Connection $conn, private LoggerInterface $logger)
     {
     }
@@ -96,8 +99,12 @@ class DbalMessageRepository implements MessageRepositoryInterface
 
     public function getChatTitle(int $chatId): string
     {
-        $row = $this->conn->fetchAssociative('SELECT title FROM chats WHERE id = ?', [$chatId]);
-        $this->logger->info('Chat title fetched', ['chat_id' => $chatId]);
-        return $row['title'] ?? '';
+        if (!array_key_exists($chatId, $this->titleCache)) {
+            $row = $this->conn->fetchAssociative('SELECT title FROM chats WHERE id = ?', [$chatId]);
+            $this->titleCache[$chatId] = $row['title'] ?? '';
+            $this->logger->info('Chat title fetched', ['chat_id' => $chatId]);
+        }
+
+        return $this->titleCache[$chatId];
     }
 }


### PR DESCRIPTION
## Summary
- Cache chat titles in the repository to prevent repeated database queries
- Notify users when no messages are available to summarize

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6891f9ce2de48322904da8420601c6e1