### PR TITLE
Add reset processed console command

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -9,6 +9,7 @@ ini_set('memory_limit', '1G');
 
 use Src\Config\Config;
 use Src\Console\DailyReportCommand;
+use Src\Console\ResetProcessedCommand;
 use Src\Repository\DbalMessageRepository;
 use Src\Service\Database;
 use Src\Service\DeepseekService;
@@ -35,5 +36,6 @@ $report = new ReportService($repo, $deepseek, $telegram, (int)Config::get('SUMMA
 
 $application = new Application();
 $application->add(new DailyReportCommand($report, $logger));
+$application->add(new ResetProcessedCommand($repo, $logger));
 $application->run();
 

--- a/src/Console/ResetProcessedCommand.php
+++ b/src/Console/ResetProcessedCommand.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Console;
+
+use Psr\Log\LoggerInterface;
+use Src\Repository\MessageRepositoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ResetProcessedCommand extends Command
+{
+    protected static $defaultName = 'app:reset-processed';
+    protected static $defaultDescription = 'Mark all messages as not processed';
+
+    public function __construct(private MessageRepositoryInterface $repo, private LoggerInterface $logger)
+    {
+        parent::__construct(self::$defaultName);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->logger->info('Reset processed command started');
+        $this->repo->resetAllProcessed();
+        $this->logger->info('Reset processed command finished');
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/DbalMessageRepository.php
+++ b/src/Repository/DbalMessageRepository.php
@@ -90,6 +90,12 @@ class DbalMessageRepository implements MessageRepositoryInterface
         $this->logger->info('Messages marked processed', ['chat_id' => $chatId]);
     }
 
+    public function resetAllProcessed(): void
+    {
+        $this->conn->executeStatement('UPDATE messages SET processed = 0');
+        $this->logger->info('All messages marked unprocessed');
+    }
+
     public function listChats(): array
     {
         $rows = $this->conn->fetchAllAssociative('SELECT id, title FROM chats ORDER BY id');

--- a/src/Repository/MessageRepositoryInterface.php
+++ b/src/Repository/MessageRepositoryInterface.php
@@ -18,6 +18,8 @@ interface MessageRepositoryInterface
 
     public function markProcessed(int $chatId, int $dayTs): void;
 
+    public function resetAllProcessed(): void;
+
     public function listChats(): array;
 
     public function getChatTitle(int $chatId): string;

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -34,4 +34,15 @@ class DatabaseTest extends TestCase
 
         $this->assertSame('', $repo->getChatTitle(1));
     }
+
+    public function testResetAllProcessed(): void
+    {
+        $repo = new DbalMessageRepository($this->conn, new NullLogger());
+        $now = time();
+        $repo->add(1, ['message_id' => 10, 'from' => ['username' => 'u'], 'date' => $now, 'text' => 'hello']);
+        $repo->markProcessed(1, $now);
+        $this->assertCount(0, $repo->getMessagesForChat(1, $now));
+        $repo->resetAllProcessed();
+        $this->assertCount(1, $repo->getMessagesForChat(1, $now));
+    }
 }

--- a/tests/ResetProcessedCommandTest.php
+++ b/tests/ResetProcessedCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Src\Console\ResetProcessedCommand;
+use Src\Repository\MessageRepositoryInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ResetProcessedCommandTest extends TestCase
+{
+    public function testResetsProcessed(): void
+    {
+        $repo = $this->createMock(MessageRepositoryInterface::class);
+        $repo->expects($this->once())->method('resetAllProcessed');
+        $command = new ResetProcessedCommand($repo, new NullLogger());
+        $app = new Application();
+        $app->add($command);
+        $tester = new CommandTester($app->find('app:reset-processed'));
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary
- add `app:reset-processed` command to mark all messages unprocessed
- support reset in message repository
- cover with tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6891ffc70c088322b9aa36afed019336