### PR TITLE
Add utility console commands

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -9,6 +9,8 @@ ini_set('memory_limit', '1G');
 
 use Src\Config\Config;
 use Src\Console\DailyReportCommand;
+use Src\Console\ChatReportCommand;
+use Src\Console\ListChatsCommand;
 use Src\Repository\DbalMessageRepository;
 use Src\Service\Database;
 use Src\Service\DeepseekService;
@@ -35,5 +37,7 @@ $report = new ReportService($repo, $deepseek, $telegram, (int)Config::get('SUMMA
 
 $application = new Application();
 $application->add(new DailyReportCommand($report, $logger));
+$application->add(new ChatReportCommand($report, $logger));
+$application->add(new ListChatsCommand($repo, $logger));
 $application->run();
 

--- a/src/Console/ChatReportCommand.php
+++ b/src/Console/ChatReportCommand.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Console;
+
+use Psr\Log\LoggerInterface;
+use Src\Service\ReportService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ChatReportCommand extends Command
+{
+    protected static $defaultName = 'app:chat-report';
+    protected static $defaultDescription = 'Generate report for a single chat';
+
+    public function __construct(private ReportService $report, private LoggerInterface $logger)
+    {
+        parent::__construct(self::$defaultName);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('chat', InputArgument::REQUIRED, 'Chat ID')
+            ->addOption('date', null, InputOption::VALUE_OPTIONAL, 'Date in Y-m-d', date('Y-m-d'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $chatId = (int)$input->getArgument('chat');
+        $dateStr = (string)$input->getOption('date');
+        $ts = strtotime($dateStr) ?: time();
+
+        $this->logger->info('Running report for chat', ['chat_id' => $chatId, 'date' => $dateStr]);
+        $this->report->runReportForChat($chatId, $ts);
+        $this->logger->info('Chat report finished', ['chat_id' => $chatId]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/ListChatsCommand.php
+++ b/src/Console/ListChatsCommand.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Console;
+
+use Psr\Log\LoggerInterface;
+use Src\Repository\MessageRepositoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListChatsCommand extends Command
+{
+    protected static $defaultName = 'app:list-chats';
+    protected static $defaultDescription = 'List all stored chats';
+
+    public function __construct(private MessageRepositoryInterface $repo, private LoggerInterface $logger)
+    {
+        parent::__construct(self::$defaultName);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->logger->info('Listing chats');
+        $chats = $this->repo->listChats();
+        foreach ($chats as $chat) {
+            $output->writeln(sprintf('%d: %s', $chat['id'], $chat['title']));
+        }
+        $this->logger->info('Chats listed', ['count' => count($chats)]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/ChatReportCommandTest.php
+++ b/tests/ChatReportCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Src\Console\ChatReportCommand;
+use Src\Service\ReportService;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ChatReportCommandTest extends TestCase
+{
+    public function testRunsReportService(): void
+    {
+        $report = $this->createMock(ReportService::class);
+        $report->expects($this->once())
+            ->method('runReportForChat')
+            ->with(123, $this->isType('int'));
+
+        $command = new ChatReportCommand($report, new NullLogger());
+        $application = new Application();
+        $application->add($command);
+
+        $tester = new CommandTester($application->find('app:chat-report'));
+        $tester->execute(['chat' => '123']);
+        $tester->assertCommandIsSuccessful();
+    }
+}

--- a/tests/ListChatsCommandTest.php
+++ b/tests/ListChatsCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Src\Console\ListChatsCommand;
+use Src\Repository\MessageRepositoryInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ListChatsCommandTest extends TestCase
+{
+    public function testOutputsChats(): void
+    {
+        $repo = $this->createMock(MessageRepositoryInterface::class);
+        $repo->expects($this->once())
+            ->method('listChats')
+            ->willReturn([
+                ['id' => 1, 'title' => 'Chat A'],
+                ['id' => 2, 'title' => 'Chat B'],
+            ]);
+
+        $command = new ListChatsCommand($repo, new NullLogger());
+        $application = new Application();
+        $application->add($command);
+
+        $tester = new CommandTester($application->find('app:list-chats'));
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('1: Chat A', $tester->getDisplay());
+        $this->assertStringContainsString('2: Chat B', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- refactor report service to support running a report for a single chat
- add chat-report command to generate summary for a specified chat and date
- add list-chats command to view stored chat IDs and titles

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6891ffd70f6c8322a5a0f393d680c762