### PR TITLE
Restrict bot commands to allowed Telegram tags

### DIFF
--- a/src/Commands/SystemCommands/CallbackqueryCommand.php
+++ b/src/Commands/SystemCommands/CallbackqueryCommand.php
@@ -10,6 +10,7 @@ use Longman\TelegramBot\Request;
 use Psr\Log\LoggerInterface;
 use Src\Config\Config;
 use Src\Repository\DbalMessageRepository;
+use Src\Service\AuthorizationService;
 use Src\Service\Database;
 use Src\Service\DeepseekService;
 use Src\Service\LoggerService;
@@ -33,6 +34,12 @@ class CallbackqueryCommand extends SystemCommand
     public function execute(): ServerResponse
     {
         $callback = $this->getCallbackQuery();
+        $user = $callback->getFrom()->getUsername();
+        if (!AuthorizationService::isAllowed($user)) {
+            $this->logger->warning('Unauthorized callback query', ['user' => $user]);
+            return $callback->answer(['text' => 'You are not allowed to use this bot.', 'show_alert' => true]);
+        }
+
         $data = $callback->getData();
         $message = $callback->getMessage();
         $chatId = $message->getChat()->getId();

--- a/src/Commands/UserCommands/ForceSummarizeCommand.php
+++ b/src/Commands/UserCommands/ForceSummarizeCommand.php
@@ -9,6 +9,7 @@ use Longman\TelegramBot\Entities\Keyboard;
 use Psr\Log\LoggerInterface;
 use Src\Config\Config;
 use Src\Repository\DbalMessageRepository;
+use Src\Service\AuthorizationService;
 use Src\Service\Database;
 use Src\Service\DeepseekService;
 use Src\Service\LoggerService;
@@ -32,6 +33,12 @@ class ForceSummarizeCommand extends UserCommand
     public function execute(): ServerResponse
     {
         $chatId = $this->getMessage()->getChat()->getId();
+        $user = $this->getMessage()->getFrom()->getUsername();
+        if (!AuthorizationService::isAllowed($user)) {
+            $this->logger->warning('Unauthorized forcesummarize command', ['user' => $user]);
+            return $this->replyToChat('You are not allowed to use this bot.');
+        }
+
         $this->logger->info('Force summarize command triggered', ['chat_id' => $chatId]);
         $conn = Database::getConnection($this->logger);
         $repo = new DbalMessageRepository($conn, $this->logger);

--- a/src/Commands/UserCommands/StartCommand.php
+++ b/src/Commands/UserCommands/StartCommand.php
@@ -9,6 +9,7 @@ use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
 use Psr\Log\LoggerInterface;
+use Src\Service\AuthorizationService;
 use Src\Service\LoggerService;
 
 /**
@@ -38,6 +39,12 @@ class StartCommand extends UserCommand
      */
     public function execute(): ServerResponse
     {
+        $username = $this->getMessage()->getFrom()->getUsername();
+        if (!AuthorizationService::isAllowed($username)) {
+            $this->logger->warning('Unauthorized /start command', ['user' => $username]);
+            return $this->replyToChat('You are not allowed to use this bot.');
+        }
+
         $chatId = $this->getMessage()->getChat()->getId();
         $text   = 'Hey';
 

--- a/src/Commands/UserCommands/SummarizeCommand.php
+++ b/src/Commands/UserCommands/SummarizeCommand.php
@@ -9,6 +9,7 @@ use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Request;
 use Psr\Log\LoggerInterface;
 use Src\Repository\DbalMessageRepository;
+use Src\Service\AuthorizationService;
 use Src\Service\Database;
 use Src\Service\LoggerService;
 
@@ -30,6 +31,11 @@ class SummarizeCommand extends UserCommand
     {
         $chatId = $this->getMessage()->getChat()->getId();
         $user = $this->getMessage()->getFrom()->getUsername();
+        if (!AuthorizationService::isAllowed($user)) {
+            $this->logger->warning('Unauthorized summarize command', ['user' => $user]);
+            return $this->replyToChat('You are not allowed to use this bot.');
+        }
+
         $this->logger->info('Summarize command triggered', ['chat_id' => $chatId, 'user' => $user]);
 
         try {

--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Service;
+
+use Src\Config\Config;
+
+class AuthorizationService
+{
+    /**
+     * Check whether the given Telegram username is allowed to run bot commands.
+     */
+    public static function isAllowed(?string $username): bool
+    {
+        $allowed = Config::get('TELEGRAM_ALLOWED_TAGS');
+        if ($allowed === '') {
+            return true;
+        }
+
+        $allowedTags = array_map(
+            static fn (string $tag): string => ltrim(trim($tag), '@'),
+            array_filter(explode(',', $allowed))
+        );
+
+        $username = ltrim((string) $username, '@');
+
+        return in_array($username, $allowedTags, true);
+    }
+}

--- a/tests/AuthorizationServiceTest.php
+++ b/tests/AuthorizationServiceTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Src\Config\Config;
+use Src\Service\AuthorizationService;
+
+class AuthorizationServiceTest extends TestCase
+{
+    public function testAllowsAllWhenEnvMissing(): void
+    {
+        $dir = sys_get_temp_dir() . '/auth' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/.env', "\n");
+        Config::load($dir);
+        $this->assertTrue(AuthorizationService::isAllowed('anyuser'));
+    }
+
+    public function testHonorsAllowedTags(): void
+    {
+        $dir = sys_get_temp_dir() . '/auth' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/.env', "TELEGRAM_ALLOWED_TAGS=user1,user2\n");
+        Config::load($dir);
+        $this->assertTrue(AuthorizationService::isAllowed('user1'));
+        $this->assertFalse(AuthorizationService::isAllowed('user3'));
+    }
+}


### PR DESCRIPTION
## Summary
- limit bot command usage to usernames defined in `TELEGRAM_ALLOWED_TAGS`
- secure /start, /summarize, /forcesummarize, and callback handlers with authorization checks
- add tests for the new authorization logic

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689227b573a0832292545059ed2993da