### PR TITLE
Improve webhook update handling

### DIFF
--- a/public/webhook-git.php
+++ b/public/webhook-git.php
@@ -4,14 +4,14 @@ require __DIR__ . '/../vendor/autoload.php';
 use Src\Config\Config;
 use Src\Service\LoggerService;
 
-Config::load(__DIR__ . '/../');
+$projectRoot = '/var/www/summary-bot';
+Config::load($projectRoot . '/');
 $logger = LoggerService::getLogger();
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
     exit('Method Not Allowed');
 }
-
 
 $secret = Config::get('GIT_SECRET');
 $headers = getallheaders();
@@ -20,23 +20,36 @@ $payload = file_get_contents('php://input');
 $signature = hash_hmac('sha256', $payload, $secret);
 if (!isset($headers['X-Hub-Signature-256']) || $headers['X-Hub-Signature-256'] !== "sha256=$signature") {
     http_response_code(403);
-    exit("Invalid signature");
+    exit('Invalid signature');
 }
 
-$output = [];
-$status = null;
-$projectRoot = realpath(__DIR__ . '/../');
-$command = sprintf('cd %s && git pull origin master && composer install --no-interaction --no-progress 2>&1', escapeshellarg($projectRoot));
-exec($command, $output, $status);
-
-if ($status !== 0) {
-    $logger->error(
-        'Git pull or composer install failed',
-        ['output' => $output, 'status' => $status]
-    );
+if (!is_dir($projectRoot)) {
+    $logger->error('Project root not found');
     http_response_code(500);
-    exit("Git pull or composer install failed");
+    exit('Project root not found');
+}
+
+$baseCmd = 'cd ' . escapeshellarg($projectRoot) . ' && ';
+
+// Pull latest changes from the repository
+$gitOutput = [];
+$gitStatus = null;
+exec($baseCmd . 'git pull origin master 2>&1', $gitOutput, $gitStatus);
+if ($gitStatus !== 0) {
+    $logger->error('Git pull failed', ['output' => $gitOutput, 'status' => $gitStatus]);
+    http_response_code(500);
+    exit('Git pull failed');
+}
+
+// Install Composer dependencies
+$composerOutput = [];
+$composerStatus = null;
+exec($baseCmd . '/usr/bin/env composer install --no-interaction --no-progress 2>&1', $composerOutput, $composerStatus);
+if ($composerStatus !== 0) {
+    $logger->error('Composer install failed', ['output' => $composerOutput, 'status' => $composerStatus]);
+    http_response_code(500);
+    exit('Composer install failed');
 }
 
 http_response_code(200);
-echo "Webhook executed, updates from Git pulled and MySQL updates applied!";
+echo "Webhook executed, updates from Git pulled and MySQL updates applied!\n";


### PR DESCRIPTION
## Summary
- Hard fail early if project root cannot be resolved
- Execute `git pull` and `composer install` separately with detailed error logging
- Run git and composer updates from `/var/www/summary-bot` to ensure changes apply to the correct project directory

## Testing
- `composer install --no-interaction --no-progress`
- `composer test` *(fails: ReportServiceTest::testMarksActiveConversation expectation mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_6892320892988322a8f2ede2720ef0f4