### PR TITLE
Сообщение об активном обсуждении на русском

### DIFF
--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -67,7 +67,7 @@ class ReportService
                     'chat_id' => $chatId,
                     'error'   => $e->getMessage(),
                 ]);
-                $note = "\n\n⚠️ Active conversation ongoing";
+                $note = "\n\n⚠️ Активное обсуждение";
             }
         }
         $dateLine   = TextUtils::escapeMarkdown(date('Y-m-d', $now));

--- a/tests/ReportServiceTest.php
+++ b/tests/ReportServiceTest.php
@@ -107,7 +107,7 @@ class ReportServiceTest extends TestCase
 
         $telegram->expects($this->once())
             ->method('sendMessage')
-            ->with(99, $this->stringContains('Active conversation about: topic'), 'MarkdownV2');
+            ->with(99, $this->stringContains('Сейчас обсуждают: topic'), 'MarkdownV2');
 
         $repo->expects($this->once())
             ->method('markProcessed')


### PR DESCRIPTION
## Summary
- Отправляем уведомление об активном обсуждении на русском языке
- Обновляем тест, ожидающий русское уведомление

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689244861844832294ea749a76d5e3eb