### PR TITLE
Add daily digest aggregation command

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -10,6 +10,7 @@ ini_set('memory_limit', '1G');
 use Src\Config\Config;
 use Src\Console\DailyReportCommand;
 use Src\Console\ChatReportCommand;
+use Src\Console\DailyDigestCommand;
 use Src\Console\ListChatsCommand;
 use Src\Console\ResetProcessedCommand;
 use Src\Repository\DbalMessageRepository;
@@ -39,6 +40,7 @@ $report = new ReportService($repo, $deepseek, $telegram, (int)Config::get('SUMMA
 $application = new Application();
 $application->add(new DailyReportCommand($report, $logger));
 $application->add(new ChatReportCommand($report, $logger));
+$application->add(new DailyDigestCommand($report, $logger));
 $application->add(new ListChatsCommand($repo, $logger));
 $application->add(new ResetProcessedCommand($repo, $logger));
 $application->run();

--- a/src/Console/DailyDigestCommand.php
+++ b/src/Console/DailyDigestCommand.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Src\Console;
+
+use Psr\Log\LoggerInterface;
+use Src\Service\ReportService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DailyDigestCommand extends Command
+{
+    protected static $defaultName = 'app:daily-digest';
+    protected static $defaultDescription = 'Generate daily report of reports';
+
+    public function __construct(private ReportService $report, private LoggerInterface $logger)
+    {
+        parent::__construct(self::$defaultName);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->logger->info('Daily digest command started');
+        $this->report->runDigest(time());
+        $this->logger->info('Daily digest command finished');
+        return Command::SUCCESS;
+    }
+}
+


### PR DESCRIPTION
## Summary
- generate a daily digest summarizing all chat reports
- allow more detailed per-chat summaries and aggregate them into a single report

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689252f447548322bd593214b8efcd83