### PR TITLE
Refactor transcript building

### DIFF
--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -30,7 +30,7 @@ class ReportService
             return null;
         }
 
-        $transcript = TextUtils::cleanTranscript(TextUtils::buildTranscript($msgs));
+        $transcript = TextUtils::buildCleanTranscript($msgs);
         $msgCount   = count($msgs);
         $users      = array_column($msgs, 'from_user');
         $userCount  = count(array_unique($users));
@@ -87,7 +87,7 @@ class ReportService
         $lastMsgTs = $msgs[count($msgs) - 1]['message_date'];
         if ($now - $lastMsgTs < 3600) {
             $recent = array_slice($msgs, -5);
-            $recentTranscript = TextUtils::cleanTranscript(TextUtils::buildTranscript($recent));
+            $recentTranscript = TextUtils::buildCleanTranscript($recent);
             try {
                 $topic = $this->deepseek->summarizeTopic($recentTranscript, $chatTitle, $chatId);
                 $note = "\n\n⚠️ Сейчас обсуждают: {$topic}";

--- a/src/Util/TextUtils.php
+++ b/src/Util/TextUtils.php
@@ -39,6 +39,14 @@ class TextUtils
     }
 
     /**
+     * Build a transcript from messages and apply cleanup rules.
+     */
+    public static function buildCleanTranscript(array $messages): string
+    {
+        return self::cleanTranscript(self::buildTranscript($messages));
+    }
+
+    /**
      * Escape a string for safe use with Telegram MarkdownV2.
      *
      * Ported from the telegramify-markdown project to ensure proper


### PR DESCRIPTION
## Summary
- add TextUtils::buildCleanTranscript to consolidate transcript cleaning
- use buildCleanTranscript in ReportService for full and recent message sets

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68926d1036208322b87490964d364574