### PR TITLE
Format daily digest like other reports

### DIFF
--- a/tests/ReportServiceTest.php
+++ b/tests/ReportServiceTest.php
@@ -165,7 +165,7 @@ class ReportServiceTest extends TestCase
         $service->runDailyReports($day);
     }
 
-    public function testRunDigestSendsJson(): void
+    public function testRunDigestSendsFormattedText(): void
     {
         $repo = $this->createMock(MessageRepositoryInterface::class);
         $deepseek = $this->createMock(DeepseekService::class);
@@ -209,8 +209,8 @@ class ReportServiceTest extends TestCase
                 $this->callback(function (string $msg) use ($run): bool {
                     $date = str_replace('-', '\\-', date('Y-m-d', $run));
                     return str_contains($msg, "*Дневной дайджест*\n_{$date}_")
-                        && str_contains($msg, '```json')
-                        && str_contains($msg, '{"overall_status":"ok"}');
+                        && !str_contains($msg, '```json')
+                        && str_contains($msg, '*Статус*: ok');
                 }),
                 'MarkdownV2'
             );


### PR DESCRIPTION
## Summary
- Format daily digest output with a new helper that converts executive JSON summaries into Markdown
- Send digest messages to Telegram as formatted text instead of raw JSON
- Update tests to expect Markdown output for digests

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6899e40d005483229e0e68cd9f1ab41d