### PR TITLE
Escape dashes in daily digest output

### DIFF
--- a/src/Service/Reports/ReportService.php
+++ b/src/Service/Reports/ReportService.php
@@ -156,7 +156,8 @@ class ReportService
                 if (is_array($item)) {
                     $item = json_encode($item, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
                 }
-                $lines[] = '- ' . TextUtils::escapeMarkdown((string)$item);
+                // Telegram MarkdownV2 requires dashes to be escaped
+                $lines[] = '\\- ' . TextUtils::escapeMarkdown((string)$item);
             }
         }
 


### PR DESCRIPTION
## Summary
- Escape dash characters in executive digest items so Telegram MarkdownV2 parses correctly

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6899e7c69d64832288f0adc06e0d42c1