### PR TITLE
Refactor JSON formatting for reports

### DIFF
--- a/src/Service/Reports/ReportService.php
+++ b/src/Service/Reports/ReportService.php
@@ -140,56 +140,22 @@ class ReportService
     /**
      * Convert executive report JSON into a Markdown formatted text.
      */
-    private function formatExecutiveReport(string $json): string
-    {
-        $data = json_decode($json, true);
-        if (!is_array($data)) {
-            return TextUtils::escapeMarkdown($json);
-        }
-
-        unset($data['chat_id'], $data['date']);
-
-        $lines = [];
-        if (isset($data['overall_status'])) {
-            $lines[] = '*Статус*: ' . TextUtils::escapeMarkdown((string) $data['overall_status']);
-            unset($data['overall_status']);
-        }
-
-        foreach ($data as $section => $items) {
-            if (is_array($items)) {
-                if (empty($items)) {
-                    continue;
-                }
-                $lines[] = '';
-                $sectionName = str_replace('_', ' ', (string) $section);
-                $lines[] = '*' . TextUtils::escapeMarkdown(ucfirst($sectionName)) . '*';
-                foreach ($items as $item) {
-                    if (is_array($item)) {
-                        $item = json_encode($item, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-                    }
-                    $lines[] = '\\- ' . TextUtils::escapeMarkdown((string) $item);
-                }
-                continue;
-            }
-            if ($items === '' || $items === null) {
-                continue;
-            }
-            $sectionName = str_replace('_', ' ', (string) $section);
-            $lines[] = '';
-            $lines[] = '*' . TextUtils::escapeMarkdown(ucfirst($sectionName)) . '*: ' . TextUtils::escapeMarkdown((string) $items);
-        }
-
-        return implode("\n", $lines);
-    }
-
     /**
-     * Convert executive digest JSON into a Markdown formatted text.
+     * Convert a JSON report or digest into a Markdown formatted text suitable for Telegram.
+     *
+     * The incoming JSON is expected to contain several top level sections with either scalar
+     * values or lists.  Scalars are rendered as key-value pairs while lists are rendered as
+     * bullet lists.  All values are escaped for MarkdownV2.
      */
-    private function formatExecutiveDigest(string $json): string
+    private function formatJsonMessage(string $json, bool $stripMeta = false): string
     {
         $data = json_decode($json, true);
         if (!is_array($data)) {
             return TextUtils::escapeMarkdown($json);
+        }
+
+        if ($stripMeta) {
+            unset($data['chat_id'], $data['date']);
         }
 
         $lines = [];
@@ -224,6 +190,19 @@ class ReportService
         }
 
         return implode("\n", $lines);
+    }
+
+    private function formatExecutiveReport(string $json): string
+    {
+        return $this->formatJsonMessage($json, true);
+    }
+
+    /**
+     * Convert executive digest JSON into a Markdown formatted text.
+     */
+    private function formatExecutiveDigest(string $json): string
+    {
+        return $this->formatJsonMessage($json);
     }
 
     public function runDigest(int $now, string $style = 'executive'): void

--- a/tests/ReportServiceFormattingTest.php
+++ b/tests/ReportServiceFormattingTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Src\Service\Reports\ReportService;
+use Src\Repository\MessageRepositoryInterface;
+use Src\Service\Integrations\DeepseekService;
+use Src\Service\Telegram\TelegramService;
+
+class ReportServiceFormattingTest extends TestCase
+{
+    private function service(): ReportService
+    {
+        $repo = $this->createMock(MessageRepositoryInterface::class);
+        $deepseek = $this->createMock(DeepseekService::class);
+        $telegram = $this->createMock(TelegramService::class);
+
+        return new ReportService($repo, $deepseek, $telegram, 1);
+    }
+
+    public function testFormatExecutiveReport(): void
+    {
+        $json = json_encode([
+            'chat_id' => 123,
+            'date' => '2024-01-01',
+            'overall_status' => 'ok',
+            'warnings' => ['test'],
+            'client_mood' => 'happy',
+        ], JSON_UNESCAPED_UNICODE);
+
+        $service = $this->service();
+        $ref = new ReflectionClass($service);
+        $method = $ref->getMethod('formatExecutiveReport');
+        $method->setAccessible(true);
+
+        $expected = "*Статус*: ok\n\n*Warnings*\n\\- test\n\n*Client mood*: happy";
+        $this->assertSame($expected, $method->invoke($service, $json));
+    }
+
+    public function testFormatExecutiveDigest(): void
+    {
+        $json = json_encode([
+            'overall_status' => 'warning',
+            'issues' => ['a', 'b'],
+        ], JSON_UNESCAPED_UNICODE);
+
+        $service = $this->service();
+        $ref = new ReflectionClass($service);
+        $method = $ref->getMethod('formatExecutiveDigest');
+        $method->setAccessible(true);
+
+        $expected = "*Статус*: warning\n\n*Issues*\n\\- a\n\\- b";
+        $this->assertSame($expected, $method->invoke($service, $json));
+    }
+}


### PR DESCRIPTION
## Summary
- refactor JSON report formatting into a shared helper
- ensure chat-report, daily report and daily digest use same Markdown-safe formatting
- add unit tests for executive report/digest formatting

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689be6eec8448322bf93b99f1d8fc71c